### PR TITLE
Enable portrait and landscape device orientation scanning for 1D barcodes

### DIFF
--- a/ZXing.Net.MAUI/ZXingBarcodeReader.cs
+++ b/ZXing.Net.MAUI/ZXingBarcodeReader.cs
@@ -12,8 +12,8 @@ namespace ZXing.Net.Maui.Readers
 		{
 			zxingReader = new BarcodeReaderGeneric()
 			{
-                AutoRotate = true,
-            };
+				AutoRotate = true,
+			};
 		}
 
 		BarcodeReaderOptions options;

--- a/ZXing.Net.MAUI/ZXingBarcodeReader.cs
+++ b/ZXing.Net.MAUI/ZXingBarcodeReader.cs
@@ -10,7 +10,10 @@ namespace ZXing.Net.Maui.Readers
 
 		public ZXingBarcodeReader()
 		{
-			zxingReader = new BarcodeReaderGeneric();
+			zxingReader = new BarcodeReaderGeneric()
+			{
+                AutoRotate = true,
+            };
 		}
 
 		BarcodeReaderOptions options;


### PR DESCRIPTION
Right now 1 dimensional barcodes could only be scanned in landscape mode. Setting the `BarcodeReaderGeneric.AutoRotate` property to true will enable it for all orientations.

This should be hooked up to the `Options.AutoRotate` but somehow it seems that setting the `BarcodeReaderGeneric.AutoRotate` afterwards doesn't seem to work? At least this fixes it for now I guess...