### PR TITLE
fix android crash on Android 5.1

### DIFF
--- a/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
+++ b/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
@@ -25,7 +25,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
 		<PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.1.0" />
 		<PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.1.0" />
-		<PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.1.0-beta02" />
+		<PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.1.0" />
 
 		<AndroidManifest Include="Platforms/Android/AndroidManifest.xml" />
 	</ItemGroup>


### PR DESCRIPTION
fix #32 

refer to the[ link](https://stackoverflow.com/questions/72376505/camerax-unexpected-rotation-value-1-on-api-22-lollipop-5-1)