### PR TITLE
ZXingNetExtension filter null values  (PDF417 Exception)

### DIFF
--- a/BigIslandBarcode/BigIslandBarcode.csproj
+++ b/BigIslandBarcode/BigIslandBarcode.csproj
@@ -12,7 +12,7 @@
 		<ApplicationTitle>BigIslandBarcode</ApplicationTitle>
 
 		<!-- App Identifier -->
-		<ApplicationId>com.greenit.companion</ApplicationId>
+		<ApplicationId>com.companyname.BigIslandBarcode</ApplicationId>
 		<ApplicationIdGuid>5D90C946-B749-4BC7-A409-868C44D73056</ApplicationIdGuid>
 		
 		<!-- Versions -->
@@ -30,10 +30,6 @@
 
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0-ios|AnyCPU'">
-	  <CodesignProvision>Automatic</CodesignProvision>
-	  <CodesignKey>iPhone Developer</CodesignKey>
-	</PropertyGroup>
 	<ItemGroup>
 		<!-- App Icon -->
 		<MauiImage Include="Resources\appicon.svg" ForegroundScale="0.8" ForegroundFile="Resources\appiconfg.svg" IsAppIcon="true" Color="#512BD4" />

--- a/BigIslandBarcode/BigIslandBarcode.csproj
+++ b/BigIslandBarcode/BigIslandBarcode.csproj
@@ -12,7 +12,7 @@
 		<ApplicationTitle>BigIslandBarcode</ApplicationTitle>
 
 		<!-- App Identifier -->
-		<ApplicationId>com.companyname.BigIslandBarcode</ApplicationId>
+		<ApplicationId>com.greenit.companion</ApplicationId>
 		<ApplicationIdGuid>5D90C946-B749-4BC7-A409-868C44D73056</ApplicationIdGuid>
 		
 		<!-- Versions -->
@@ -30,6 +30,10 @@
 
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0-ios|AnyCPU'">
+	  <CodesignProvision>Automatic</CodesignProvision>
+	  <CodesignKey>iPhone Developer</CodesignKey>
+	</PropertyGroup>
 	<ItemGroup>
 		<!-- App Icon -->
 		<MauiImage Include="Resources\appicon.svg" ForegroundScale="0.8" ForegroundFile="Resources\appiconfg.svg" IsAppIcon="true" Color="#512BD4" />

--- a/ZXing.Net.MAUI/ZXingNetExtensions.cs
+++ b/ZXing.Net.MAUI/ZXingNetExtensions.cs
@@ -4,26 +4,32 @@ using Microsoft.Maui.Graphics;
 
 namespace ZXing.Net.Maui
 {
-	public static class ZXingNetExtensions
-	{
-		public static BarcodeResult ToBarcodeResult(this ZXing.Result result)
-			=> new()
-			{
-				Raw = result.RawBytes,
-				Value = result.Text,
-				Format = (BarcodeFormat)(int)result.BarcodeFormat,
-				Metadata = new Dictionary<MetadataType, object>(result?.ResultMetadata?.Select(md => new KeyValuePair<MetadataType, object> ((MetadataType)md.Key, md.Value))),
-				PointsOfInterest = result?.ResultPoints?.Select(p => new PointF(p.X, p.Y))?.ToArray()
-			};
+    public static class ZXingNetExtensions
+    {
+        public static BarcodeResult ToBarcodeResult(this ZXing.Result result)
+            => new()
+            {
+                Raw = result.RawBytes,
+                Value = result.Text,
+                Format = (BarcodeFormat)(int)result.BarcodeFormat,
+                Metadata = new Dictionary<MetadataType, object>(result?.ResultMetadata?.Select(md => new KeyValuePair<MetadataType, object>((MetadataType)md.Key, md.Value))),
+                PointsOfInterest = result?.ResultPoints?.Select(p => new PointF(p.X, p.Y))?.ToArray()
+            };
 
-		public static BarcodeResult[] ToBarcodeResults(this ZXing.Result[] results)
-			=> results?.Select(result => new BarcodeResult()
-			{
-				Raw = result.RawBytes,
-				Value = result.Text,
-				Format = (BarcodeFormat)(int)result.BarcodeFormat,
-				Metadata = new Dictionary<MetadataType, object>(result?.ResultMetadata?.Select(md => new KeyValuePair<MetadataType, object>((MetadataType)md.Key, md.Value))),
-				PointsOfInterest = result?.ResultPoints?.Select(p => new PointF(p.X, p.Y))?.ToArray()
-			})?.ToArray();
-	}
+        public static BarcodeResult[] ToBarcodeResults(this ZXing.Result[] results)
+            => results?.Select(result => new BarcodeResult()
+            {
+                Raw = result.RawBytes,
+                Value = result.Text,
+                Format = (BarcodeFormat)(int)result.BarcodeFormat,
+                Metadata = new Dictionary<MetadataType, object>(result?.ResultMetadata?.Select(md => new KeyValuePair<MetadataType, object>((MetadataType)md.Key, md.Value))),
+                PointsOfInterest = result?.ResultPoints?
+                    .Where(p => p is not null)
+                    .Select(p =>
+                    {
+                        return new PointF(p.X, p.Y);
+
+                    })?.ToArray()
+            })?.ToArray();
+    }
 }

--- a/ZXing.Net.MAUI/ZXingNetExtensions.cs
+++ b/ZXing.Net.MAUI/ZXingNetExtensions.cs
@@ -14,8 +14,8 @@ namespace ZXing.Net.Maui
                 Format = (BarcodeFormat)(int)result.BarcodeFormat,
                 Metadata = new Dictionary<MetadataType, object>(result?.ResultMetadata?.Select(md => new KeyValuePair<MetadataType, object>((MetadataType)md.Key, md.Value))),
                 PointsOfInterest = result?.ResultPoints?
-                    .Where(p => p is not null)
-                    .Select(p => new PointF(p.X, p.Y))?.ToArray()
+                .Where(p => p is not null)
+                .Select(p => new PointF(p.X, p.Y))?.ToArray()
             };
 
         public static BarcodeResult[] ToBarcodeResults(this ZXing.Result[] results)
@@ -26,12 +26,8 @@ namespace ZXing.Net.Maui
                 Format = (BarcodeFormat)(int)result.BarcodeFormat,
                 Metadata = new Dictionary<MetadataType, object>(result?.ResultMetadata?.Select(md => new KeyValuePair<MetadataType, object>((MetadataType)md.Key, md.Value))),
                 PointsOfInterest = result?.ResultPoints?
-                    .Where(p => p is not null)
-                    .Select(p =>
-                    {
-                        return new PointF(p.X, p.Y);
-
-                    })?.ToArray()
+                .Where(p => p is not null)
+                .Select(p => new PointF(p.X, p.Y))?.ToArray()
             })?.ToArray();
     }
 }

--- a/ZXing.Net.MAUI/ZXingNetExtensions.cs
+++ b/ZXing.Net.MAUI/ZXingNetExtensions.cs
@@ -13,7 +13,9 @@ namespace ZXing.Net.Maui
                 Value = result.Text,
                 Format = (BarcodeFormat)(int)result.BarcodeFormat,
                 Metadata = new Dictionary<MetadataType, object>(result?.ResultMetadata?.Select(md => new KeyValuePair<MetadataType, object>((MetadataType)md.Key, md.Value))),
-                PointsOfInterest = result?.ResultPoints?.Select(p => new PointF(p.X, p.Y))?.ToArray()
+                PointsOfInterest = result?.ResultPoints?
+                    .Where(p => p is not null)
+                    .Select(p => new PointF(p.X, p.Y))?.ToArray()
             };
 
         public static BarcodeResult[] ToBarcodeResults(this ZXing.Result[] results)


### PR DESCRIPTION
In some cases when I am scanning pdf417 format the decoder returns null points.
A null point filter has been added to avoid the exception.