### PR TITLE
fix(scanner): Fix missing camera

### DIFF
--- a/BigIslandBarcode/App.xaml.cs
+++ b/BigIslandBarcode/App.xaml.cs
@@ -1,17 +1,16 @@
-﻿using Microsoft.Maui;
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.PlatformConfiguration.WindowsSpecific;
-using Application = Microsoft.Maui.Controls.Application;
+﻿using Application = Microsoft.Maui.Controls.Application;
 
-namespace BigIslandBarcode
+namespace BigIslandBarcode;
+
+public partial class App : Application
 {
-	public partial class App : Application
+	public App()
 	{
-		public App()
-		{
-			InitializeComponent();
+		InitializeComponent();
 
-			MainPage = new MainPage();
-		}
+		MainPage = new MainPage();
+
+		// uncomment this to test scanner within flyout page
+		//MainPage = new MainPageWithFlyout();
 	}
 }

--- a/BigIslandBarcode/BigIslandBarcode.csproj
+++ b/BigIslandBarcode/BigIslandBarcode.csproj
@@ -48,4 +48,16 @@
 		<ProjectReference Include="..\ZXing.Net.MAUI\ZXing.Net.MAUI.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <Compile Update="MainPageWithFlyout.xaml.cs">
+	    <DependentUpon>MainPageWithFlyout.xaml</DependentUpon>
+	  </Compile>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <MauiXaml Update="MainPageWithFlyout.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	</ItemGroup>
+
 </Project>

--- a/BigIslandBarcode/MainPageWithFlyout.xaml
+++ b/BigIslandBarcode/MainPageWithFlyout.xaml
@@ -1,0 +1,22 @@
+﻿<FlyoutPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:zxing="clr-namespace:ZXing.Net.Maui.Controls;assembly=ZXing.Net.MAUI"
+    xmlns:local="clr-namespace:BigIslandBarcode"
+	x:Class="BigIslandBarcode.MainPageWithFlyout"
+	BackgroundColor="#000000"
+    Title="Foo">
+
+    <FlyoutPage.Flyout>
+        <ContentPage Title="Bar">
+            <Label Text="This is just a test" />
+        </ContentPage>
+    </FlyoutPage.Flyout>
+
+    <FlyoutPage.Detail>
+        <NavigationPage>
+            <x:Arguments>
+                <local:MainPage />
+            </x:Arguments>
+        </NavigationPage>
+    </FlyoutPage.Detail>
+</FlyoutPage>

--- a/BigIslandBarcode/MainPageWithFlyout.xaml.cs
+++ b/BigIslandBarcode/MainPageWithFlyout.xaml.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Maui.Controls;
+
+namespace BigIslandBarcode;
+
+public partial class MainPageWithFlyout : FlyoutPage
+{
+	public MainPageWithFlyout()
+	{
+		InitializeComponent();
+	}
+}

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -97,10 +97,17 @@ namespace ZXing.Net.Maui
 				if (cameraSelector == null)
 					throw new System.Exception("Camera not found");
 
-				// The Context here SHOULD be something that's a lifecycle owner
-				if (Context.Context is AndroidX.Lifecycle.ILifecycleOwner lifecycleOwner)
-					camera = cameraProvider.BindToLifecycle(lifecycleOwner, cameraSelector, cameraPreview, imageAnalyzer);
-			}
+                // The Context here SHOULD be something that's a lifecycle owner
+                if (Context.Context is AndroidX.Lifecycle.ILifecycleOwner lifecycleOwner)
+                {
+                    camera = cameraProvider.BindToLifecycle(lifecycleOwner, cameraSelector, cameraPreview, imageAnalyzer);
+                }
+                // if not, this should be sufficient as a fallback
+                else if (Microsoft.Maui.ApplicationModel.Platform.CurrentActivity is AndroidX.Lifecycle.ILifecycleOwner maLifecycleOwner)
+                {
+                    camera = cameraProvider.BindToLifecycle(maLifecycleOwner, cameraSelector, cameraPreview, imageAnalyzer);
+                }
+            }
 		}
 
 		public void UpdateTorch(bool on)


### PR DESCRIPTION
fixed camera not getting assigned by using current activity as a fallback.

I also added a flyout page to the test application to reproduce. I am not aware if this issue is occuring on iOS. I do not have a device to test that.

Closes #7