### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The successor to ZXing.Net.Mobile: barcode scanning and generation for .NET MAUI
 
 ### Install ZXing.Net.MAUI
 
-1. Install [ZXing.Net.MAUI](https://www.nuget.org/packages/ZXing.Net.Maui) NuGet package on your .NET MAUI application
+1. Install [ZXing.Net.Maui.Controls](https://www.nuget.org/packages/ZXing.Net.Maui.Controls) NuGet package on your .NET MAUI application
 
 1. Make sure to initialize the plugin first in your `MauiProgram.cs`, see below
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For more information on permissions, see the [Microsoft Docs](https://docs.micro
 
 ### Using ZXing.Net.Maui
 
-If you're using the controls from XAML, make sure to add the right XML namespace in the root of your file, e.g: `xmlns:zxing="clr-namespace:ZXing.Net.Maui.Controls;assembly=ZXing.Net.MAUI"`
+If you're using the controls from XAML, make sure to add the right XML namespace in the root of your file, e.g: `xmlns:zxing="clr-namespace:ZXing.Net.Maui.Controls;assembly=ZXing.Net.MAUI.Controls"`
 
 ```xaml
 <zxing:CameraBarcodeReaderView


### PR DESCRIPTION
Fixed #55
Fixed #59
Fixed #73
Fixed #74
Fixed #78
Fixed #90
Fixed #117

Since 0.2.0-preview.2, CameraBarcodeReaderView and BarcodeGeneratorView were moved from [ZXing.Net.Maui](https://www.nuget.org/packages/ZXing.Net.Maui) to [ZXing.Net.Maui.Controls](https://www.nuget.org/packages/ZXing.Net.Maui.Controls).
However, this change was not reflected in the README, causing confusion.
This PR will bring the README up to date to clear up this confusion.
