### PR TITLE
Fixed app crash on iOS simulators

### DIFF
--- a/ZXing.Net.MAUI/Apple/CameraManager.ios.maccatalyst.cs
+++ b/ZXing.Net.MAUI/Apple/CameraManager.ios.maccatalyst.cs
@@ -126,6 +126,9 @@ namespace ZXing.Net.Maui
 				if (captureDevice == null)
 					captureDevice = AVCaptureDevice.GetDefaultDevice(AVMediaTypes.Video);
 
+				if (captureDevice is null)
+					return;
+
 				captureInput = new AVCaptureDeviceInput(captureDevice, out var err);
 
 				captureSession.AddInput(captureInput);


### PR DESCRIPTION
I added an early exit from the UpdateCamera() method, so the app doesn't crash anymore when running on the iOS simulator.

Fixes https://github.com/Redth/ZXing.Net.Maui/issues/114