### PR TITLE
Added support for the UseCode39ExtendedMode option

### DIFF
--- a/ZXing.Net.MAUI/BarcodeScannerOptions.cs
+++ b/ZXing.Net.MAUI/BarcodeScannerOptions.cs
@@ -13,5 +13,7 @@
 
 		public bool Multiple { get; init; }
 
-	}
+		public bool UseCode39ExtendedMode { get; init; }
+
+    }
 }

--- a/ZXing.Net.MAUI/ZXingBarcodeReader.cs
+++ b/ZXing.Net.MAUI/ZXingBarcodeReader.cs
@@ -23,7 +23,8 @@ namespace ZXing.Net.Maui.Readers
 				zxingReader.Options.TryHarder = options.TryHarder;
 				zxingReader.AutoRotate = options.AutoRotate;
 				zxingReader.Options.TryInverted = options.TryInverted;
-			}
+				zxingReader.Options.UseCode39ExtendedMode = options.UseCode39ExtendedMode;
+            }
 		}
 
 		public BarcodeResult[] Decode(PixelBufferHolder image)


### PR DESCRIPTION
Added the UseCode39ExtendedMode option to the BarcodeReaderOptions class and attached this option to the DecodingOptions in the ZXingBarcodeReader class.