### PR TITLE
Update iOS orientation handling for application orientation and orientation changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4.2.2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4.1.0
       with:
         dotnet-version: '7.0.x'
     - name: Setup NuGet 5.x
@@ -52,7 +52,7 @@ jobs:
         nuget sign .\artifacts\*.nupkg -CertificatePath $pfxPath -Timestamper http://timestamp.entrust.net/TSS/RFC3161sha2TS
         
     - name: Artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: NuGet
         path: ./artifacts
@@ -64,11 +64,11 @@ jobs:
     if: github.event_name == 'release'
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4.1.8
         with:
           name: NuGet
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4.1.0
         with:
           dotnet-version: '7.0.x'
       - name: Push NuGet


### PR DESCRIPTION
Update iOS orientation to follow application orientation using the last key window. Falls back to no transformation if no key windows found.

Also observe device orientation changes and update layout subview when it changes. Remove the observer when the camera is disconnected.

This is an update to pull request #43 in response to issue #40.