### PR TITLE
Update iOS BarcodeBitmapRenderer to use UIGraphicsImaegeRenderer

### DIFF
--- a/ZXing.Net.MAUI/Apple/BarcodeBitmapRenderer.ios.maccatalyst.cs
+++ b/ZXing.Net.MAUI/Apple/BarcodeBitmapRenderer.ios.maccatalyst.cs
@@ -3,6 +3,8 @@ using ZXing.Rendering;
 using Microsoft.Maui.Graphics.Platform;
 using MauiColor = Microsoft.Maui.Graphics.Color;
 using ZXing.Common;
+using System.Threading;
+
 
 #if IOS || MACCATALYST
 using Foundation;

--- a/ZXing.Net.MAUI/Apple/BarcodeBitmapRenderer.ios.maccatalyst.cs
+++ b/ZXing.Net.MAUI/Apple/BarcodeBitmapRenderer.ios.maccatalyst.cs
@@ -42,23 +42,39 @@ namespace ZXing.Net.Maui
 
 		public UIImage Render(BitMatrix matrix, ZXing.BarcodeFormat format, string content, EncodingOptions options)
 		{
-			UIGraphics.BeginImageContext(new CGSize(matrix.Width, matrix.Height));
-			var context = UIGraphics.GetCurrentContext();
+			var renderer = new UIGraphicsImageRenderer(new CGSize(matrix.Width, matrix.Height), new UIGraphicsImageRendererFormat {
+				Opaque = false,
+				Scale = UIScreen.MainScreen.Scale
+			});
 
-			for (var x = 0; x < matrix.Width; x++)
+			var waiter = new ManualResetEvent(false);
+			UIImage image = null!;
+			
+			renderer.CreateImage(context =>
 			{
-				for (var y = 0; y < matrix.Height; y++)
+				var black = new CGColor(0f, 0f, 0f);
+				var white = new CGColor(1.0f, 1.0f, 1.0f);
+				
+				for (var x = 0; x < matrix.Width; x++)
 				{
-					context.SetFillColor(matrix[x, y] ? ForegroundColor : BackgroundColor);
-					context.FillRect(new CGRect(x, y, 1, 1));
+					for (var y = 0; y < matrix.Height; y++)
+					{
+						context.CGContext.SetFillColor(matrix[x, y] ? black : white);
+						context.CGContext.FillRect(new CGRect(x, y, 1, 1));
+					}
 				}
+				
+				SetImage(context.CurrentImage);
+			});
+
+			waiter.WaitOne();
+			return image;
+			
+			void SetImage(UIImage img)
+			{
+				image = img;
+				waiter.Set();
 			}
-
-			var img = UIGraphics.GetImageFromCurrentImageContext();
-
-			UIGraphics.EndImageContext();
-
-			return img;
 		}
 	}
 }

--- a/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
+++ b/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
@@ -23,9 +23,9 @@
 		<IsPackable>true</IsPackable>
 	</PropertyGroup>
 	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
-		<PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.3.4.2" />
-		<PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.3.4.2" />
-		<PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.3.4.2" />
+		<PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.1.0" />
+		<PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.1.0" />
+		<PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.1.0" />
 
 		<AndroidManifest Include="Platforms/Android/AndroidManifest.xml" />
 	</ItemGroup>


### PR DESCRIPTION
iOS 17 deprecated UIGraphics.BeginImageContext in favor of using UIGraphcsImageRenderer.

Fixes #189 