### PR TITLE
Bugfix null view exception

### DIFF
--- a/ZXing.Net.MAUI/CameraBarcodeReaderViewHandler.cs
+++ b/ZXing.Net.MAUI/CameraBarcodeReaderViewHandler.cs
@@ -51,17 +51,23 @@ namespace ZXing.Net.Maui
         {
             base.ConnectHandler(nativeView);
 
-            if (await cameraManager.CheckPermissions())
-                cameraManager.Connect();
+            if (cameraManager != null)
+            {
+                if (await cameraManager.CheckPermissions())
+                    cameraManager.Connect();
 
-            cameraManager.FrameReady += CameraManager_FrameReady;
+                cameraManager.FrameReady += CameraManager_FrameReady;
+            }
         }
 
         protected override void DisconnectHandler(NativePlatformCameraPreviewView nativeView)
         {
-            cameraManager.FrameReady -= CameraManager_FrameReady;
+            if (cameraManager != null)
+            {
+                cameraManager.FrameReady -= CameraManager_FrameReady;
 
-            cameraManager.Disconnect();
+                cameraManager.Disconnect();
+            }
 
             base.DisconnectHandler(nativeView);
         }
@@ -70,7 +76,7 @@ namespace ZXing.Net.Maui
         {
             VirtualView?.FrameReady(e);
 
-            if (VirtualView.IsDetecting)
+            if (VirtualView?.IsDetecting ?? false)
             {
                 var barcodes = BarcodeReader.Decode(e.Data);
 

--- a/ZXing.Net.MAUI/CameraViewHandler.cs
+++ b/ZXing.Net.MAUI/CameraViewHandler.cs
@@ -44,11 +44,14 @@ namespace ZXing.Net.Maui
 		protected override async void ConnectHandler(NativePlatformCameraPreviewView nativeView)
 		{
 			base.ConnectHandler(nativeView);
+   
+			if (cameraManager != null)
+			{
+				if (await cameraManager.CheckPermissions())
+					cameraManager.Connect();
 
-			if (await cameraManager.CheckPermissions())
-				cameraManager.Connect();
-
-			cameraManager.FrameReady += CameraManager_FrameReady;
+				cameraManager.FrameReady += CameraManager_FrameReady;
+			}
 		}
 
 		void CameraManager_FrameReady(object sender, CameraFrameBufferEventArgs e)
@@ -56,9 +59,12 @@ namespace ZXing.Net.Maui
 
         protected override void DisconnectHandler(NativePlatformCameraPreviewView nativeView)
 		{
-			cameraManager.FrameReady -= CameraManager_FrameReady;
+			if (cameraManager != null)
+			{
+				cameraManager.FrameReady -= CameraManager_FrameReady;
 
-			cameraManager.Disconnect();
+				cameraManager.Disconnect();
+			}
 
 			base.DisconnectHandler(nativeView);
 		}


### PR DESCRIPTION
This PR addresses two possible null object exceptions.

1. Update CameraBarcodeReaderViewHandler and CameraViewHandler classes to handle when cameraManager is null. This exception has not been encountered, but adding the safety net just in case it is possible.
2. Fix bug in CameraBarcodeReaderViewHandle.CameraManager_FrameReady method, the VirtualView.IsDetecting was not handling case of VirtualView being null while the rest of the access was properly handling. This exception has been encountered when using this library.