### PR TITLE
Fixed missing RowStride usage when extracting Luminance

### DIFF
--- a/ZXing.Net.MAUI/Platforms/Android/FrameAnalyzer.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/FrameAnalyzer.cs
@@ -8,6 +8,8 @@ namespace ZXing.Net.Maui
 	internal class FrameAnalyzer : Java.Lang.Object, ImageAnalysis.IAnalyzer
 	{
 		readonly Action<ByteBuffer, Size> frameCallback;
+		ByteBuffer tempBuffer;
+		byte[] tempRow;
 
 		public FrameAnalyzer(Action<ByteBuffer, Size> callback)
 		{
@@ -16,7 +18,36 @@ namespace ZXing.Net.Maui
 
 		public void Analyze(IImageProxy image)
 		{
-			var buffer = image.GetPlanes()[0].Buffer;
+			ByteBuffer buffer;
+
+			var plane = image.GetPlanes()[0];
+			var stride = plane.RowStride;
+			var width = image.Width;
+			if (stride == width)
+			{
+				buffer = plane.Buffer;
+			}
+			else
+			{
+				if (tempRow == null || tempRow.Length < width)
+					tempRow = new byte[width];
+
+				var height = image.Height;
+				var bufferSize = width * height;
+				if (tempBuffer == null || tempBuffer.Capacity() < bufferSize)
+					tempBuffer = ByteBuffer.Allocate(bufferSize);
+
+				var source = plane.Buffer;                
+				for (int y = 0; y < height; y++)
+				{
+					source.Position(y * stride);
+					source.Get(tempRow, 0, width);
+					tempBuffer.Position(y * width);
+					tempBuffer.Put(tempRow, 0, width);
+				}
+
+				buffer = tempBuffer;
+			}
 
 			var s = new Size(image.Width, image.Height);
 


### PR DESCRIPTION
Without this fix the actual image that comes to the decoder looks like this

![image](https://github.com/user-attachments/assets/49dfafbb-0dd6-4447-ad6f-27a2e104077f)
