### PR TITLE
Fixes crashes Android 15 and update to net9

### DIFF
--- a/BigIslandBarcode/BigIslandBarcode.csproj
+++ b/BigIslandBarcode/BigIslandBarcode.csproj
@@ -53,7 +53,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.10" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.21" />
 	</ItemGroup>
 
 </Project>

--- a/BigIslandBarcode/BigIslandBarcode.csproj
+++ b/BigIslandBarcode/BigIslandBarcode.csproj
@@ -2,8 +2,8 @@
 
 	<PropertyGroup>
 		<!-- iOS, Android, MacCatalyst -->
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<SingleProject>true</SingleProject>
 		<UseMaui>true</UseMaui>
@@ -53,7 +53,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.82" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.10" />
 	</ItemGroup>
 
 </Project>

--- a/ZXing.Net.MAUI.Comet/ZXing.Net.MAUI.Comet.csproj
+++ b/ZXing.Net.MAUI.Comet/ZXing.Net.MAUI.Comet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net8.0-android;net8.0-maccatalyst;net8.0-ios</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks>net9.0;net9.0-android;net9.0-maccatalyst;net9.0-ios</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041</TargetFrameworks>
 		<PackageId>ZXing.Net.Maui.Comet</PackageId>
 		<Title>ZXing.Net.MAUI Barcode Scanner for .NET MAUI</Title>
 		<Authors>Redth</Authors>
@@ -26,6 +26,6 @@
 	  <ProjectReference Include="..\ZXing.Net.MAUI\ZXing.Net.MAUI.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.82" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.10" />
 	</ItemGroup>
 </Project>

--- a/ZXing.Net.MAUI.Comet/ZXing.Net.MAUI.Comet.csproj
+++ b/ZXing.Net.MAUI.Comet/ZXing.Net.MAUI.Comet.csproj
@@ -26,6 +26,6 @@
 	  <ProjectReference Include="..\ZXing.Net.MAUI\ZXing.Net.MAUI.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.10" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.21" />
 	</ItemGroup>
 </Project>

--- a/ZXing.Net.MAUI.Controls/ZXing.Net.MAUI.Controls.csproj
+++ b/ZXing.Net.MAUI.Controls/ZXing.Net.MAUI.Controls.csproj
@@ -25,6 +25,6 @@
 	  <ProjectReference Include="..\ZXing.Net.MAUI\ZXing.Net.MAUI.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.10" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.21" />
 	</ItemGroup>
 </Project>

--- a/ZXing.Net.MAUI.Controls/ZXing.Net.MAUI.Controls.csproj
+++ b/ZXing.Net.MAUI.Controls/ZXing.Net.MAUI.Controls.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net8.0-android;net8.0-maccatalyst;net8.0-ios</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks>net9.0;net9.0-android;net9.0-maccatalyst;net9.0-ios</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041</TargetFrameworks>
 		<PackageId>ZXing.Net.Maui.Controls</PackageId>
 		<Title>ZXing.Net.MAUI Barcode Scanner for .NET MAUI</Title>
 		<Authors>Redth</Authors>
@@ -25,6 +25,6 @@
 	  <ProjectReference Include="..\ZXing.Net.MAUI\ZXing.Net.MAUI.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.82" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.10" />
 	</ItemGroup>
 </Project>

--- a/ZXing.Net.MAUI.Controls/ZXing.Net.MAUI.Controls.csproj
+++ b/ZXing.Net.MAUI.Controls/ZXing.Net.MAUI.Controls.csproj
@@ -25,6 +25,6 @@
 	  <ProjectReference Include="..\ZXing.Net.MAUI\ZXing.Net.MAUI.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.21" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.30" />
 	</ItemGroup>
 </Project>

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -58,7 +58,7 @@ namespace ZXing.Net.Maui
 
 				// Preview
 				cameraPreview = new AndroidX.Camera.Core.Preview.Builder().Build();
-				cameraPreview.SetSurfaceProvider(previewView.SurfaceProvider);
+				cameraPreview.SetSurfaceProvider(cameraExecutor, previewView.SurfaceProvider);
 
 				// Frame by frame analyze
 				imageAnalyzer = new ImageAnalysis.Builder()
@@ -67,7 +67,7 @@ namespace ZXing.Net.Maui
 					.Build();
 
 				imageAnalyzer.SetAnalyzer(cameraExecutor, new FrameAnalyzer((buffer, size) =>
-					FrameReady?.Invoke(this, new CameraFrameBufferEventArgs(new Readers.PixelBufferHolder { Data = buffer, Size = size }))));
+					FrameReady?.Invoke(this, new CameraFrameBufferEventArgs(new Readers.PixelBufferHolder { Data = buffer, Size = new Microsoft.Maui.Graphics.Size(size.Width, size.Height) }))));
 
 				UpdateCamera();
 

--- a/ZXing.Net.MAUI/Platforms/Android/FrameAnalyzer.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/FrameAnalyzer.cs
@@ -2,10 +2,11 @@
 using Java.Nio;
 using Microsoft.Maui.Graphics;
 using System;
+using Size = Android.Util.Size;
 
 namespace ZXing.Net.Maui
 {
-	internal class FrameAnalyzer : Java.Lang.Object, ImageAnalysis.IAnalyzer
+	public class FrameAnalyzer : Java.Lang.Object, ImageAnalysis.IAnalyzer
 	{
 		readonly Action<ByteBuffer, Size> frameCallback;
 
@@ -13,6 +14,8 @@ namespace ZXing.Net.Maui
 		{
 			frameCallback = callback;
 		}
+
+        public Size DefaultTargetResolution => new Size(200, 200);
 
 		public void Analyze(IImageProxy image)
 		{

--- a/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
+++ b/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
@@ -88,6 +88,6 @@
 	</Target>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.21" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.30" />
 	</ItemGroup>
 </Project>

--- a/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
+++ b/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
@@ -88,6 +88,6 @@
 	</Target>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.10" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.21" />
 	</ItemGroup>
 </Project>

--- a/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
+++ b/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net8.0-android;net8.0-maccatalyst;net8.0-ios</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks>net9.0;net9.0-android;net9.0-maccatalyst;net9.0-ios</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041</TargetFrameworks>
 		<PackageId>ZXing.Net.Maui</PackageId>
 		<Title>ZXing.Net.MAUI Barcode Scanner for .NET MAUI</Title>
 		<Authors>Redth</Authors>
@@ -88,6 +88,6 @@
 	</Target>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.82" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.10" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Updates to net9

Fixes crashes on Android:

System.MissingMethodException: 'Method not found: void AndroidX.Camera.Core.Preview.SetSurfaceProvider(AndroidX.Camera.Core.Preview/ISurfaceProvider)'

AbstractMethodError: abstract method "android.util.Size androidx.camera.core.ImageAnalysis$Analyzer.getDefaultTargetResolution()" => https://github.com/dotnet/android-libraries/issues/767#issuecomment-1658163275
