### PR TITLE
Android: added possibility to select scale type of camera preview (fixes #250)

### DIFF
--- a/BigIslandBarcode/MainPage.xaml
+++ b/BigIslandBarcode/MainPage.xaml
@@ -7,7 +7,7 @@
 	<Grid RowDefinitions="1*,3*,1*">
 
 		<zxing:CameraBarcodeReaderView
-			Grid.Row="0" Grid.RowSpan="3"
+            Grid.Row="1" 
 			x:Name="barcodeView"
 			BarcodesDetected="BarcodesDetected"
 			 />
@@ -19,18 +19,20 @@
 		</Grid>
 
 		<Grid
-			Grid.Row="3"
+            Grid.Row="2"
 			BackgroundColor="#aa000000"
 			Padding="20"
-			ColumnDefinitions="Auto,Auto,*,Auto">
+			ColumnDefinitions="Auto,Auto,Auto,*,Auto">
 
 			<Button Text="🔄️" Grid.Column="0" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="SwitchCameraButton_Clicked" />
 
 			<Button Text="📷" Grid.Column="1" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="SelectCameraButton_Clicked" />
 
-			<zxing:BarcodeGeneratorView
+            <Button Text="🔍" Grid.Column="2" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="SelectScaleType_Clicked" />
+
+            <zxing:BarcodeGeneratorView
 				x:Name="barcodeGenerator"
-				Grid.Column="2"
+				Grid.Column="3"
 				HorizontalOptions="Center"
 				VerticalOptions="Center"
 				HeightRequest="100"
@@ -41,7 +43,7 @@
 				CharacterSet="UTF-8"
 				BarcodeMargin="1" />
 
-			<Button Text="💡" Grid.Column="3" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="TorchButton_Clicked" />
+			<Button Text="💡" Grid.Column="4" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="TorchButton_Clicked" />
 		</Grid>
 
 	</Grid>

--- a/BigIslandBarcode/MainPage.xaml.cs
+++ b/BigIslandBarcode/MainPage.xaml.cs
@@ -76,7 +76,16 @@ namespace BigIslandBarcode
 			}
 		}
 
-		void TorchButton_Clicked(object sender, EventArgs e)
+        async void SelectScaleType_Clicked(object sender, EventArgs e)
+        {
+            var selectedScaleType = await DisplayActionSheet("Select Scale Type", "Cancel", null, Enum.GetNames(typeof(PreviewScaleType)));
+            if (selectedScaleType != null && selectedScaleType != "Cancel")
+            {
+                barcodeView.PreviewScaleType = (PreviewScaleType)Enum.Parse(typeof(PreviewScaleType), selectedScaleType);
+            }
+        }
+
+        void TorchButton_Clicked(object sender, EventArgs e)
 		{
 			barcodeView.IsTorchOn = !barcodeView.IsTorchOn;
 		}

--- a/BigIslandBarcode/MainPage.xaml.cs
+++ b/BigIslandBarcode/MainPage.xaml.cs
@@ -78,10 +78,13 @@ namespace BigIslandBarcode
 
         async void SelectScaleType_Clicked(object sender, EventArgs e)
         {
-            var selectedScaleType = await DisplayActionSheet("Select Scale Type", "Cancel", null, Enum.GetNames(typeof(PreviewScaleType)));
-            if (selectedScaleType != null && selectedScaleType != "Cancel")
+            var selectedScaleType = await ShowPickerDialogAsync("Select Scale Type", Enum.GetNames(typeof(PreviewScaleType)));
+            if (selectedScaleType != null)
             {
-                barcodeView.PreviewScaleType = (PreviewScaleType)Enum.Parse(typeof(PreviewScaleType), selectedScaleType);
+                if (Enum.TryParse<PreviewScaleType>(selectedScaleType, out var scaleType))
+                {
+                    barcodeView.PreviewScaleType = scaleType;
+                }
             }
         }
 

--- a/ZXing.Net.MAUI.Controls/Controls/CameraBarcodeReaderView.cs
+++ b/ZXing.Net.MAUI.Controls/Controls/CameraBarcodeReaderView.cs
@@ -62,7 +62,16 @@ namespace ZXing.Net.Maui.Controls
 			set => SetValue(SelectedCameraProperty, value);
 		}
 
-		public void AutoFocus()
+        public static readonly BindableProperty PreviewScaleTypeProperty =
+            BindableProperty.Create(nameof(PreviewScaleType), typeof(PreviewScaleType), typeof(CameraBarcodeReaderView), defaultValue: PreviewScaleType.FillCenter);
+
+        public PreviewScaleType PreviewScaleType
+        {
+            get => (PreviewScaleType)GetValue(PreviewScaleTypeProperty);
+            set => SetValue(PreviewScaleTypeProperty, value);
+        }
+
+        public void AutoFocus()
 			=> StrongHandler?.Invoke(nameof(AutoFocus), null);
 
 		public void Focus(Point point)

--- a/ZXing.Net.MAUI.Controls/Controls/CameraView.cs
+++ b/ZXing.Net.MAUI.Controls/Controls/CameraView.cs
@@ -40,7 +40,17 @@ namespace ZXing.Net.Maui.Controls
 			set => SetValue(SelectedCameraProperty, value);
 		}
 
-		public void AutoFocus()
+        public static readonly BindableProperty PreviewScaleTypeProperty =
+            BindableProperty.Create(nameof(PreviewScaleType), typeof(PreviewScaleType), typeof(CameraView), defaultValue: PreviewScaleType.FillCenter);
+
+        public PreviewScaleType PreviewScaleType
+        {
+            get => (PreviewScaleType)GetValue(PreviewScaleTypeProperty);
+            set => SetValue(PreviewScaleTypeProperty, value);
+        }
+
+
+        public void AutoFocus()
 			=> StrongHandler?.Invoke(nameof(AutoFocus), null);
 
 		public void Focus(Point point)

--- a/ZXing.Net.MAUI.Controls/Controls/CameraView.cs
+++ b/ZXing.Net.MAUI.Controls/Controls/CameraView.cs
@@ -49,7 +49,6 @@ namespace ZXing.Net.Maui.Controls
             set => SetValue(PreviewScaleTypeProperty, value);
         }
 
-
         public void AutoFocus()
 			=> StrongHandler?.Invoke(nameof(AutoFocus), null);
 

--- a/ZXing.Net.MAUI.Controls/ZXing.Net.MAUI.Controls.csproj
+++ b/ZXing.Net.MAUI.Controls/ZXing.Net.MAUI.Controls.csproj
@@ -2,8 +2,8 @@
 	<PropertyGroup>
     <TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041</TargetFrameworks>
-    <PackageId>Zoka.ZXing.Net.Maui.Controls</PackageId>
-		<Title>Zoka.ZXing.Net.MAUI Barcode Scanner for .NET MAUI</Title>
+    <PackageId>ZXing.Net.Maui.Controls</PackageId>
+		<Title>ZXing.Net.MAUI Barcode Scanner for .NET MAUI</Title>
 		<Authors>Redth</Authors>
 		<UseMaui>True</UseMaui>
 		<SingleProject>True</SingleProject>

--- a/ZXing.Net.MAUI.Controls/ZXing.Net.MAUI.Controls.csproj
+++ b/ZXing.Net.MAUI.Controls/ZXing.Net.MAUI.Controls.csproj
@@ -2,8 +2,8 @@
 	<PropertyGroup>
     <TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041</TargetFrameworks>
-    <PackageId>ZXing.Net.Maui.Controls</PackageId>
-		<Title>ZXing.Net.MAUI Barcode Scanner for .NET MAUI</Title>
+    <PackageId>Zoka.ZXing.Net.Maui.Controls</PackageId>
+		<Title>Zoka.ZXing.Net.MAUI Barcode Scanner for .NET MAUI</Title>
 		<Authors>Redth</Authors>
 		<UseMaui>True</UseMaui>
 		<SingleProject>True</SingleProject>

--- a/ZXing.Net.MAUI/CameraBarcodeReaderViewHandler.cs
+++ b/ZXing.Net.MAUI/CameraBarcodeReaderViewHandler.cs
@@ -18,7 +18,8 @@ namespace ZXing.Net.Maui
             [nameof(ICameraBarcodeReaderView.IsDetecting)] = MapIsDetecting,
             [nameof(ICameraBarcodeReaderView.IsTorchOn)] = (handler, virtualView) => handler.cameraManager?.UpdateTorch(virtualView.IsTorchOn),
             [nameof(ICameraBarcodeReaderView.CameraLocation)] = (handler, virtualView) => handler.cameraManager?.UpdateCameraLocation(virtualView.CameraLocation),
-            [nameof(ICameraBarcodeReaderView.SelectedCamera)] = (handler, virtualView) => handler.cameraManager?.UpdateSelectedCamera(virtualView.SelectedCamera)
+            [nameof(ICameraBarcodeReaderView.SelectedCamera)] = (handler, virtualView) => handler.cameraManager?.UpdateSelectedCamera(virtualView.SelectedCamera),
+            [nameof(ICameraBarcodeReaderView.PreviewScaleType)] = (handler, virtualView) => handler.cameraManager?.UpdatePreviewScaleType(virtualView.PreviewScaleType)
         };
 
         public static CommandMapper<ICameraBarcodeReaderView, CameraBarcodeReaderViewHandler> CameraBarcodeReaderCommandMapper = new()

--- a/ZXing.Net.MAUI/CameraManager.cs
+++ b/ZXing.Net.MAUI/CameraManager.cs
@@ -23,7 +23,9 @@ namespace ZXing.Net.Maui
 		public CameraLocation CameraLocation { get; private set; }
 		public CameraInfo SelectedCamera { get; private set; }
 
-		public void UpdateCameraLocation(CameraLocation cameraLocation)
+        public PreviewScaleType PreviewScaleType { get; set; }
+
+        public void UpdateCameraLocation(CameraLocation cameraLocation)
 		{
 			CameraLocation = cameraLocation;
 			SelectedCamera = null;
@@ -42,7 +44,13 @@ namespace ZXing.Net.Maui
 			UpdateCamera();
 		}
 
-		public static async Task<bool> CheckPermissions()
+        public void UpdatePreviewScaleType(PreviewScaleType scaleType)
+        {
+            PreviewScaleType = scaleType;
+            UpdateCamera();
+        }
+
+        public static async Task<bool> CheckPermissions()
 			=> (await Permissions.RequestAsync<Permissions.Camera>()) == PermissionStatus.Granted;
 	}
 }

--- a/ZXing.Net.MAUI/ICameraView.cs
+++ b/ZXing.Net.MAUI/ICameraView.cs
@@ -14,6 +14,10 @@ namespace ZXing.Net.Maui
 
 		CameraInfo SelectedCamera { get; set; }
 
+        /// <summary>
+        /// Gets or sets the scale type for the camera preview. Controls how the preview is scaled within its container.
+        /// Primarily used on Android to address preview overflow issues.
+        /// </summary>
         PreviewScaleType PreviewScaleType { get; set; }
 
         //CameraMode Mode { get; set; }

--- a/ZXing.Net.MAUI/ICameraView.cs
+++ b/ZXing.Net.MAUI/ICameraView.cs
@@ -14,9 +14,11 @@ namespace ZXing.Net.Maui
 
 		CameraInfo SelectedCamera { get; set; }
 
-		//CameraMode Mode { get; set; }
+        PreviewScaleType PreviewScaleType { get; set; }
 
-		void AutoFocus();
+        //CameraMode Mode { get; set; }
+
+        void AutoFocus();
 
 		void Focus(Point point);
 

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Versioning;
+﻿using System;
+using System.Runtime.Versioning;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,6 +13,8 @@ using AndroidX.Camera.View;
 using AndroidX.Core.Content;
 
 using Java.Util.Concurrent;
+
+using Microsoft.Maui.Controls.PlatformConfiguration;
 
 namespace ZXing.Net.Maui
 {
@@ -126,6 +129,19 @@ namespace ZXing.Net.Maui
                 if (_cameraSelector == null)
                     throw new System.Exception("Camera not found");
 
+                PreviewView.ScaleType scaleType = PreviewScaleType switch
+                {
+                    PreviewScaleType.FitCenter => PreviewView.ScaleType.FitCenter,
+                    PreviewScaleType.FillEnd => PreviewView.ScaleType.FillEnd,
+                    PreviewScaleType.FillStart => PreviewView.ScaleType.FillStart,
+                    PreviewScaleType.FitEnd => PreviewView.ScaleType.FitEnd,
+                    PreviewScaleType.FitStart => PreviewView.ScaleType.FitStart,
+                    PreviewScaleType.FillCenter => PreviewView.ScaleType.FillCenter,
+                    _ => throw new ArgumentOutOfRangeException(nameof(PreviewScaleType), PreviewScaleType,
+                        "Invalid value of PreviewScaleType")
+                };
+
+                _previewView.SetScaleType(scaleType);
                 // The Context here SHOULD be something that's a lifecycle owner
                 if (Context.Context is AndroidX.Lifecycle.ILifecycleOwner lifecycleOwner)
                 {

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -14,8 +14,6 @@ using AndroidX.Core.Content;
 
 using Java.Util.Concurrent;
 
-using Microsoft.Maui.Controls.PlatformConfiguration;
-
 namespace ZXing.Net.Maui
 {
     internal partial class CameraManager
@@ -138,7 +136,7 @@ namespace ZXing.Net.Maui
                     PreviewScaleType.FitStart => PreviewView.ScaleType.FitStart,
                     PreviewScaleType.FillCenter => PreviewView.ScaleType.FillCenter,
                     _ => throw new ArgumentOutOfRangeException(nameof(PreviewScaleType), PreviewScaleType,
-                        "Invalid value of PreviewScaleType")
+                        $"Invalid PreviewScaleType value: {PreviewScaleType}")
                 };
 
                 _previewView.SetScaleType(scaleType);

--- a/ZXing.Net.MAUI/PreviewScaleType.cs
+++ b/ZXing.Net.MAUI/PreviewScaleType.cs
@@ -1,11 +1,35 @@
 ﻿namespace ZXing.Net.Maui;
 
+/// <summary>
+/// Defines how the camera preview should be scaled and aligned within its container.
+/// "Fill" scales the preview to fill the container, possibly cropping the image.
+/// "Fit" scales the preview to fit entirely within the container, possibly leaving empty space.
+/// "Center", "Start", and "End" specify the alignment of the preview within the container.
+/// </summary>
 public enum PreviewScaleType
 {
+    /// <summary>
+    /// Scale the preview uniformly to fill the container, cropping as needed, and center it.
+    /// </summary>
     FillCenter,
+    /// <summary>
+    /// Scale the preview uniformly to fill the container, cropping as needed, and align it to the start (top or left).
+    /// </summary>
     FillStart,
+    /// <summary>
+    /// Scale the preview uniformly to fill the container, cropping as needed, and align it to the end (bottom or right).
+    /// </summary>
     FillEnd,
+    /// <summary>
+    /// Scale the preview uniformly to fit entirely within the container, centering it. No cropping, may leave empty space.
+    /// </summary>
     FitCenter,
+    /// <summary>
+    /// Scale the preview uniformly to fit entirely within the container, aligning it to the start (top or left). No cropping, may leave empty space.
+    /// </summary>
     FitStart,
+    /// <summary>
+    /// Scale the preview uniformly to fit entirely within the container, aligning it to the end (bottom or right). No cropping, may leave empty space.
+    /// </summary>
     FitEnd,
 }

--- a/ZXing.Net.MAUI/PreviewScaleType.cs
+++ b/ZXing.Net.MAUI/PreviewScaleType.cs
@@ -1,0 +1,11 @@
+﻿namespace ZXing.Net.Maui;
+
+public enum PreviewScaleType
+{
+    FillCenter,
+    FillStart,
+    FillEnd,
+    FitCenter,
+    FitStart,
+    FitEnd,
+}


### PR DESCRIPTION
In this PR I have added new parametr `PreviewScaleType` into the `CameraBarcodeReaderView` and `CameraView` which allow user to schange the scaling of the preview. The problem was described in #250 and this should be the solution to this problem.
I have also adapted the example, so you may check the results in app. At the moment I have not possibility to check the behaviour on the iPhone (but I do not expect, that on iPhone it will overflow). On windows user do not experience overflow of preview. It seems to be problem only on Android. 
Feel free to adapt the code as needed.