### PR TITLE
Add ZoomFactor property and implement platform zoom on iOS/Android/Windows

### DIFF
--- a/BigIslandBarcode/MainPage.xaml
+++ b/BigIslandBarcode/MainPage.xaml
@@ -11,13 +11,15 @@
 			x:Name="barcodeView"
 			BarcodesDetected="BarcodesDetected"
 			 />
-
-		<Grid
+        <Grid Grid.Row="1" VerticalOptions="End" HorizontalOptions="Fill" BackgroundColor="#aa000000">
+            <Slider Minimum="0" Maximum="1" ValueChanged="ZoomFactorChanged" />
+        </Grid>
+        <Grid
 			Grid.Row="0"
 			BackgroundColor="#aa000000">
 			<Label x:Name="ResultLabel" Grid.Row="2" Text="Top text..." HorizontalOptions="Center" VerticalOptions="Center" TextColor="White" />
 		</Grid>
-
+        
 		<Grid
 			Grid.Row="3"
 			BackgroundColor="#aa000000"
@@ -27,8 +29,8 @@
 			<Button Text="🔄️" Grid.Column="0" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="SwitchCameraButton_Clicked" />
 
 			<Button Text="📷" Grid.Column="1" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="SelectCameraButton_Clicked" />
-
-			<zxing:BarcodeGeneratorView
+            
+            <zxing:BarcodeGeneratorView
 				x:Name="barcodeGenerator"
 				Grid.Column="2"
 				HorizontalOptions="Center"

--- a/BigIslandBarcode/MainPage.xaml
+++ b/BigIslandBarcode/MainPage.xaml
@@ -7,19 +7,25 @@
 	<Grid RowDefinitions="1*,3*,1*">
 
 		<zxing:CameraBarcodeReaderView
-			Grid.Row="0" Grid.RowSpan="3"
+			Grid.Row="0"
+			Grid.RowSpan="3"
 			x:Name="barcodeView"
-			BarcodesDetected="BarcodesDetected"
-			 />
-        <Grid Grid.Row="1" VerticalOptions="End" HorizontalOptions="Fill" BackgroundColor="#aa000000">
-            <Slider Minimum="0" Maximum="1" ValueChanged="ZoomFactorChanged" />
-        </Grid>
-        <Grid
+			BarcodesDetected="BarcodesDetected" />
+
+		<Grid
+			Grid.Row="1"
+			VerticalOptions="End"
+			HorizontalOptions="Fill"
+			BackgroundColor="#aa000000">
+			<Slider Minimum="0" Maximum="1" ValueChanged="ZoomFactorChanged" />
+		</Grid>
+
+		<Grid
 			Grid.Row="0"
 			BackgroundColor="#aa000000">
 			<Label x:Name="ResultLabel" Grid.Row="2" Text="Top text..." HorizontalOptions="Center" VerticalOptions="Center" TextColor="White" />
 		</Grid>
-        
+
 		<Grid
 			Grid.Row="3"
 			BackgroundColor="#aa000000"
@@ -29,8 +35,8 @@
 			<Button Text="🔄️" Grid.Column="0" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="SwitchCameraButton_Clicked" />
 
 			<Button Text="📷" Grid.Column="1" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="SelectCameraButton_Clicked" />
-            
-            <zxing:BarcodeGeneratorView
+
+			<zxing:BarcodeGeneratorView
 				x:Name="barcodeGenerator"
 				Grid.Column="2"
 				HorizontalOptions="Center"

--- a/BigIslandBarcode/MainPage.xaml.cs
+++ b/BigIslandBarcode/MainPage.xaml.cs
@@ -96,5 +96,12 @@ namespace BigIslandBarcode
 		{
 			barcodeView.IsTorchOn = !barcodeView.IsTorchOn;
 		}
-	}
+
+        private void ZoomFactorChanged(object sender, ValueChangedEventArgs e)
+        {
+            var slider = (Slider)sender;
+            barcodeView.ZoomFactor = (float)e.NewValue;
+
+        }
+    }
 }

--- a/BigIslandBarcode/MainPage.xaml.cs
+++ b/BigIslandBarcode/MainPage.xaml.cs
@@ -97,11 +97,9 @@ namespace BigIslandBarcode
 			barcodeView.IsTorchOn = !barcodeView.IsTorchOn;
 		}
 
-        private void ZoomFactorChanged(object sender, ValueChangedEventArgs e)
-        {
-            var slider = (Slider)sender;
-            barcodeView.ZoomFactor = (float)e.NewValue;
-
-        }
-    }
+		void ZoomFactorChanged(object sender, ValueChangedEventArgs e)
+		{
+			barcodeView.ZoomFactor = (float)e.NewValue;
+		}
+	}
 }

--- a/BigIslandBarcode/MainPage.xaml.cs
+++ b/BigIslandBarcode/MainPage.xaml.cs
@@ -80,5 +80,12 @@ namespace BigIslandBarcode
 		{
 			barcodeView.IsTorchOn = !barcodeView.IsTorchOn;
 		}
-	}
+
+        private void ZoomFactorChanged(object sender, ValueChangedEventArgs e)
+        {
+            var slider = (Slider)sender;
+            barcodeView.ZoomFactor = (float)e.NewValue;
+
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ Toggle Torch
 cameraBarcodeReaderView.IsTorchOn = !cameraBarcodeReaderView.IsTorchOn;
 ```
 
+Set zoom
+```csharp
+// 0 = minimum zoom, 1 = maximum zoom. Values outside this range are clamped.
+cameraBarcodeReaderView.ZoomFactor = 0.5f;
+```
+
+The zoom factor is normalized from `0` to `1` across platforms. Android uses CameraX linear zoom, iOS maps the value to the active device zoom range capped at `5x`, and Windows maps it to the device `ZoomControl` range when supported.
+
 Flip between Rear/Front cameras
 ```csharp
 cameraBarcodeReaderView.CameraLocation
@@ -184,4 +192,3 @@ If you need to encode international characters (e.g., Chinese, Japanese, Arabic,
 ```
 
 The `CharacterSet` property is not set by default, which lets the barcode encoder use its native encoding. This avoids adding ECI (Extended Channel Interpretation) headers that some barcode scanners may not support. Common values include "UTF-8", "ISO-8859-1", "Shift_JIS", etc., depending on your barcode format requirements.
-

--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ Toggle Torch
 cameraBarcodeReaderView.IsTorchOn = !cameraBarcodeReaderView.IsTorchOn;
 ```
 
+Set zoom (normalized 0..1)
+```csharp
+// 0 = minimum, 1 = maximum (values outside the range are clamped)
+cameraBarcodeReaderView.ZoomFactor = 0.5f;
+```
+
+Notes on zoom behavior:
+- The zoom factor is normalized (0..1) across platforms.
+- iOS maps 0..1 to the device zoom range [1, max], where max is capped to the maximum optical zoom (currently min of `ActiveFormat.VideoMaxZoomFactor` and `5x`) to avoid degraded digital zoom.
+- Android uses linear zoom via CameraX.
+- Windows maps the normalized value to the device `ZoomControl` range when supported.
+
 Flip between Rear/Front cameras
 ```csharp
 cameraBarcodeReaderView.CameraLocation
@@ -172,7 +184,6 @@ The `BarcodeGeneratorView` supports UTF-8 character encoding by default, which a
 ```
 
 The `CharacterSet` property defaults to "UTF-8" if not specified. Other common values include "ISO-8859-1", "Shift_JIS", etc., depending on your barcode format requirements.
-
 
 
 

--- a/ZXing.Net.MAUI.Controls/Controls/CameraBarcodeReaderView.cs
+++ b/ZXing.Net.MAUI.Controls/Controls/CameraBarcodeReaderView.cs
@@ -63,7 +63,8 @@ namespace ZXing.Net.Maui.Controls
 		}
 
 		public static readonly BindableProperty ZoomFactorProperty =
-			BindableProperty.Create(nameof(ZoomFactor), typeof(float), typeof(CameraBarcodeReaderView), defaultValue: 0f);
+			BindableProperty.Create(nameof(ZoomFactor), typeof(float), typeof(CameraBarcodeReaderView), defaultValue: 0f,
+				coerceValue: static (_, value) => Math.Clamp((float)value, 0f, 1f));
 
 		public float ZoomFactor
 		{

--- a/ZXing.Net.MAUI.Controls/Controls/CameraBarcodeReaderView.cs
+++ b/ZXing.Net.MAUI.Controls/Controls/CameraBarcodeReaderView.cs
@@ -64,7 +64,7 @@ namespace ZXing.Net.Maui.Controls
 
 		public static readonly BindableProperty ZoomFactorProperty =
 			BindableProperty.Create(nameof(ZoomFactor), typeof(float), typeof(CameraBarcodeReaderView), defaultValue: 0f,
-				coerceValue: static (_, value) => Math.Clamp((float)value, 0f, 1f));
+				coerceValue: ZoomFactorPropertyHelper.Coerce);
 
 		public float ZoomFactor
 		{

--- a/ZXing.Net.MAUI.Controls/Controls/CameraBarcodeReaderView.cs
+++ b/ZXing.Net.MAUI.Controls/Controls/CameraBarcodeReaderView.cs
@@ -62,6 +62,15 @@ namespace ZXing.Net.Maui.Controls
 			set => SetValue(SelectedCameraProperty, value);
 		}
 
+		public static readonly BindableProperty ZoomFactorProperty =
+			BindableProperty.Create(nameof(ZoomFactor), typeof(float), typeof(CameraBarcodeReaderView), defaultValue: 0f);
+
+		public float ZoomFactor
+		{
+			get => (float)GetValue(ZoomFactorProperty);
+			set => SetValue(ZoomFactorProperty, value);
+		}
+
 		public void AutoFocus()
 			=> StrongHandler?.Invoke(nameof(AutoFocus), null);
 

--- a/ZXing.Net.MAUI.Controls/Controls/CameraView.cs
+++ b/ZXing.Net.MAUI.Controls/Controls/CameraView.cs
@@ -40,6 +40,15 @@ namespace ZXing.Net.Maui.Controls
 			set => SetValue(SelectedCameraProperty, value);
 		}
 
+		public static readonly BindableProperty ZoomFactorProperty =
+			BindableProperty.Create(nameof(ZoomFactor), typeof(float), typeof(CameraView), defaultValue: 0f);
+
+		public float ZoomFactor
+		{
+			get => (float)GetValue(ZoomFactorProperty);
+			set => SetValue(ZoomFactorProperty, value);
+		}
+
 		public void AutoFocus()
 			=> StrongHandler?.Invoke(nameof(AutoFocus), null);
 

--- a/ZXing.Net.MAUI.Controls/Controls/CameraView.cs
+++ b/ZXing.Net.MAUI.Controls/Controls/CameraView.cs
@@ -42,7 +42,7 @@ namespace ZXing.Net.Maui.Controls
 
 		public static readonly BindableProperty ZoomFactorProperty =
 			BindableProperty.Create(nameof(ZoomFactor), typeof(float), typeof(CameraView), defaultValue: 0f,
-				coerceValue: static (_, value) => Math.Clamp((float)value, 0f, 1f));
+				coerceValue: ZoomFactorPropertyHelper.Coerce);
 
 		public float ZoomFactor
 		{

--- a/ZXing.Net.MAUI.Controls/Controls/CameraView.cs
+++ b/ZXing.Net.MAUI.Controls/Controls/CameraView.cs
@@ -41,7 +41,8 @@ namespace ZXing.Net.Maui.Controls
 		}
 
 		public static readonly BindableProperty ZoomFactorProperty =
-			BindableProperty.Create(nameof(ZoomFactor), typeof(float), typeof(CameraView), defaultValue: 0f);
+			BindableProperty.Create(nameof(ZoomFactor), typeof(float), typeof(CameraView), defaultValue: 0f,
+				coerceValue: static (_, value) => Math.Clamp((float)value, 0f, 1f));
 
 		public float ZoomFactor
 		{

--- a/ZXing.Net.MAUI.Controls/Controls/ZoomFactorPropertyHelper.cs
+++ b/ZXing.Net.MAUI.Controls/Controls/ZoomFactorPropertyHelper.cs
@@ -1,0 +1,18 @@
+using Microsoft.Maui.Controls;
+using System;
+
+namespace ZXing.Net.Maui.Controls
+{
+	static class ZoomFactorPropertyHelper
+	{
+		public static object Coerce(BindableObject bindable, object value)
+		{
+			var zoomFactor = value == null ? 0f : Convert.ToSingle(value);
+
+			if (float.IsNaN(zoomFactor))
+				return 0f;
+
+			return Math.Clamp(zoomFactor, 0f, 1f);
+		}
+	}
+}

--- a/ZXing.Net.MAUI/Apple/CameraManager.ios.maccatalyst.cs
+++ b/ZXing.Net.MAUI/Apple/CameraManager.ios.maccatalyst.cs
@@ -225,6 +225,8 @@ namespace ZXing.Net.Maui
 
 				if (wasRunning || startIfStopped)
 					captureSession.StartRunning();
+
+				ApplyZoomFactor();
 			}
 		}
 
@@ -359,6 +361,27 @@ namespace ZXing.Net.Maui
 					Console.WriteLine(ex);
 				}
 			}
+		}
+
+		partial void ApplyZoomFactor()
+		{
+			if (captureDevice == null)
+				return;
+
+			var minZoomFactor = 1f;
+			// Cap zoom to the max optical range (higher values can engage digital zoom and degrade clarity).
+			var maxZoomFactor = Math.Min((float)captureDevice.ActiveFormat.VideoMaxZoomFactor, 5.0f);
+			if (maxZoomFactor < minZoomFactor)
+				maxZoomFactor = minZoomFactor;
+
+			var normalizedZoomFactor = ZoomFactor * (maxZoomFactor - minZoomFactor) + minZoomFactor;
+			if (normalizedZoomFactor < minZoomFactor)
+				normalizedZoomFactor = minZoomFactor;
+			else if (normalizedZoomFactor > maxZoomFactor)
+				normalizedZoomFactor = maxZoomFactor;
+
+			CaptureDevicePerformWithLockedConfiguration(() =>
+				captureDevice.VideoZoomFactor = normalizedZoomFactor);
 		}
 
 		public void Focus(Microsoft.Maui.Graphics.Point point)

--- a/ZXing.Net.MAUI/Apple/CameraManager.ios.maccatalyst.cs
+++ b/ZXing.Net.MAUI/Apple/CameraManager.ios.maccatalyst.cs
@@ -199,6 +199,8 @@ namespace ZXing.Net.Maui
 				captureSession.AddInput(captureInput);
 
 				captureSession.StartRunning();
+
+				ApplyZoomFactor();
 			}
 		}
 
@@ -267,6 +269,27 @@ namespace ZXing.Net.Maui
 					Console.WriteLine(ex);
 				}
 			}
+		}
+
+		partial void ApplyZoomFactor()
+		{
+			if (captureDevice == null)
+				return;
+
+			var minZoomFactor = 1f;
+			// Cap zoom to the max optical range (higher values can engage digital zoom and degrade clarity).
+			var maxZoomFactor = Math.Min((float)captureDevice.ActiveFormat.VideoMaxZoomFactor, 5.0f);
+			if (maxZoomFactor < minZoomFactor)
+				maxZoomFactor = minZoomFactor;
+
+			var normalizedZoomFactor = ZoomFactor * (maxZoomFactor - minZoomFactor) + minZoomFactor;
+			if (normalizedZoomFactor < minZoomFactor)
+				normalizedZoomFactor = minZoomFactor;
+			else if (normalizedZoomFactor > maxZoomFactor)
+				normalizedZoomFactor = maxZoomFactor;
+
+			CaptureDevicePerformWithLockedConfiguration(() =>
+				captureDevice.VideoZoomFactor = normalizedZoomFactor);
 		}
 
 		public void Focus(Microsoft.Maui.Graphics.Point point)

--- a/ZXing.Net.MAUI/Apple/CameraManager.ios.maccatalyst.cs
+++ b/ZXing.Net.MAUI/Apple/CameraManager.ios.maccatalyst.cs
@@ -200,7 +200,6 @@ namespace ZXing.Net.Maui
 
 				captureSession.StartRunning();
 
-				ApplyZoomFactor();
 			}
 		}
 

--- a/ZXing.Net.MAUI/CameraBarcodeReaderViewHandler.cs
+++ b/ZXing.Net.MAUI/CameraBarcodeReaderViewHandler.cs
@@ -20,6 +20,7 @@ namespace ZXing.Net.Maui
             [nameof(ICameraBarcodeReaderView.IsTorchOn)] = (handler, virtualView) => handler.cameraManager?.UpdateTorch(virtualView.IsTorchOn),
             [nameof(ICameraBarcodeReaderView.CameraLocation)] = (handler, virtualView) => handler.cameraManager?.UpdateCameraLocation(virtualView.CameraLocation),
             [nameof(ICameraBarcodeReaderView.SelectedCamera)] = (handler, virtualView) => handler.cameraManager?.UpdateSelectedCamera(virtualView.SelectedCamera),
+            [nameof(ICameraBarcodeReaderView.ZoomFactor)] = (handler, virtualView) => handler.cameraManager?.UpdateZoomFactor(virtualView.ZoomFactor),
             [nameof(IView.Visibility)] = MapVisibility
         };
 

--- a/ZXing.Net.MAUI/CameraBarcodeReaderViewHandler.cs
+++ b/ZXing.Net.MAUI/CameraBarcodeReaderViewHandler.cs
@@ -19,6 +19,7 @@ namespace ZXing.Net.Maui
             [nameof(ICameraBarcodeReaderView.IsTorchOn)] = (handler, virtualView) => handler.cameraManager?.UpdateTorch(virtualView.IsTorchOn),
             [nameof(ICameraBarcodeReaderView.CameraLocation)] = (handler, virtualView) => handler.cameraManager?.UpdateCameraLocation(virtualView.CameraLocation),
             [nameof(ICameraBarcodeReaderView.SelectedCamera)] = (handler, virtualView) => handler.cameraManager?.UpdateSelectedCamera(virtualView.SelectedCamera),
+            [nameof(ICameraBarcodeReaderView.ZoomFactor)] = (handler, virtualView) => handler.cameraManager?.UpdateZoomFactor(virtualView.ZoomFactor),
             [nameof(IView.Visibility)] = MapVisibility
         };
 

--- a/ZXing.Net.MAUI/CameraManager.cs
+++ b/ZXing.Net.MAUI/CameraManager.cs
@@ -23,6 +23,7 @@ namespace ZXing.Net.Maui
 
 		public CameraLocation CameraLocation { get; private set; }
 		public CameraInfo SelectedCamera { get; private set; }
+		public float ZoomFactor { get; private set; }
 
 		protected CameraManagerOptions Options => options;
 
@@ -80,11 +81,18 @@ namespace ZXing.Net.Maui
 			return false;
 		}
 
+		public void UpdateZoomFactor(float zoomFactor)
+		{
+			ZoomFactor = Math.Clamp(zoomFactor, 0f, 1f);
+			ApplyZoomFactor();
+		}
+
 		public static async Task<bool> CheckPermissions()
 			=> (await Permissions.RequestAsync<Permissions.Camera>()) == PermissionStatus.Granted;
 
 		partial void ApplyCameraOptions();
 
 		private static partial bool ShouldApplyPlatformCameraOptions(CameraManagerOptions currentOptions, CameraManagerOptions nextOptions);
+		partial void ApplyZoomFactor();
 	}
 }

--- a/ZXing.Net.MAUI/CameraManager.cs
+++ b/ZXing.Net.MAUI/CameraManager.cs
@@ -83,6 +83,9 @@ namespace ZXing.Net.Maui
 
 		public void UpdateZoomFactor(float zoomFactor)
 		{
+			if (float.IsNaN(zoomFactor))
+				zoomFactor = 0f;
+
 			ZoomFactor = Math.Clamp(zoomFactor, 0f, 1f);
 			ApplyZoomFactor();
 		}

--- a/ZXing.Net.MAUI/CameraManager.cs
+++ b/ZXing.Net.MAUI/CameraManager.cs
@@ -22,6 +22,7 @@ namespace ZXing.Net.Maui
 
 		public CameraLocation CameraLocation { get; private set; }
 		public CameraInfo SelectedCamera { get; private set; }
+		public float ZoomFactor { get; private set; }
 
 		/// <summary>
 		/// Gets a value indicating whether barcode scanning is supported on this device.
@@ -48,7 +49,15 @@ namespace ZXing.Net.Maui
 			UpdateCamera();
 		}
 
+		public void UpdateZoomFactor(float zoomFactor)
+		{
+			ZoomFactor = Math.Clamp(zoomFactor, 0f, 1f);
+			ApplyZoomFactor();
+		}
+
 		public static async Task<bool> CheckPermissions()
 			=> (await Permissions.RequestAsync<Permissions.Camera>()) == PermissionStatus.Granted;
+
+		partial void ApplyZoomFactor();
 	}
 }

--- a/ZXing.Net.MAUI/CameraViewHandler.cs
+++ b/ZXing.Net.MAUI/CameraViewHandler.cs
@@ -15,6 +15,7 @@ namespace ZXing.Net.Maui
 			[nameof(ICameraView.IsTorchOn)] = (handler, virtualView) => handler.cameraManager?.UpdateTorch(virtualView.IsTorchOn),
 			[nameof(ICameraView.CameraLocation)] = (handler, virtualView) => handler.cameraManager?.UpdateCameraLocation(virtualView.CameraLocation),
 			[nameof(ICameraView.SelectedCamera)] = (handler, virtualView) => handler.cameraManager?.UpdateSelectedCamera(virtualView.SelectedCamera),
+			[nameof(ICameraView.ZoomFactor)] = (handler, virtualView) => handler.cameraManager?.UpdateZoomFactor(virtualView.ZoomFactor),
 			[nameof(IView.Visibility)] = MapVisibility
 		};
 

--- a/ZXing.Net.MAUI/ICameraView.cs
+++ b/ZXing.Net.MAUI/ICameraView.cs
@@ -14,7 +14,11 @@ namespace ZXing.Net.Maui
 
 		CameraInfo SelectedCamera { get; set; }
 
-		float ZoomFactor { get; set; }
+		float ZoomFactor
+		{
+			get => 0f;
+			set { }
+		}
 
 		//CameraMode Mode { get; set; }
 

--- a/ZXing.Net.MAUI/ICameraView.cs
+++ b/ZXing.Net.MAUI/ICameraView.cs
@@ -14,6 +14,8 @@ namespace ZXing.Net.Maui
 
 		CameraInfo SelectedCamera { get; set; }
 
+		float ZoomFactor { get; set; }
+
 		//CameraMode Mode { get; set; }
 
 		void AutoFocus();

--- a/ZXing.Net.MAUI/Net/CameraManager.net.cs
+++ b/ZXing.Net.MAUI/Net/CameraManager.net.cs
@@ -34,6 +34,10 @@ namespace ZXing.Net.Maui
         public void UpdateTorch(bool on)
             => LogUnsupported();
 
+        partial void ApplyZoomFactor()
+        {
+        }
+
         public void Focus(Microsoft.Maui.Graphics.Point point)
             => LogUnsupported();
 

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -173,6 +173,8 @@ namespace ZXing.Net.Maui
                     // if not, this should be sufficient as a fallback
                     _camera = cameraProvider.BindToLifecycle(maLifecycleOwner, _cameraSelector, cameraPreview, imageAnalyzer);
                 }
+
+                ApplyZoomFactor();
             }
         }
 
@@ -327,6 +329,11 @@ namespace ZXing.Net.Maui
                     .OrderByDescending(size => size.Width == selectedSize.Width && size.Height == selectedSize.Height)
                     .ToList();
             }
+        }
+
+        partial void ApplyZoomFactor()
+        {
+            _camera?.CameraControl?.SetLinearZoom(ZoomFactor);
         }
 
         public void Focus(Point point)

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -170,6 +170,8 @@ namespace ZXing.Net.Maui
                     // if not, this should be sufficient as a fallback
                     _camera = _cameraProvider.BindToLifecycle(maLifecycleOwner, _cameraSelector, _cameraPreview, _imageAnalyzer);
                 }
+
+                ApplyZoomFactor();
             }
         }
 
@@ -221,6 +223,11 @@ namespace ZXing.Net.Maui
         public void UpdateTorch(bool on)
         {
             _camera?.CameraControl?.EnableTorch(on);
+        }
+
+        partial void ApplyZoomFactor()
+        {
+            _camera?.CameraControl?.SetLinearZoom(ZoomFactor);
         }
 
         public void Focus(Point point)

--- a/ZXing.Net.MAUI/Platforms/Windows/CameraManager.windows.cs
+++ b/ZXing.Net.MAUI/Platforms/Windows/CameraManager.windows.cs
@@ -729,6 +729,14 @@ namespace ZXing.Net.Maui
 				normalizedZoom = maxZoom;
 
 			var zoomStep = (float)zoomControl.Step;
+			if (zoomStep > 0f)
+				normalizedZoom = (float)Math.Round((normalizedZoom - minZoom) / zoomStep) * zoomStep + minZoom;
+
+			if (normalizedZoom < minZoom)
+				normalizedZoom = minZoom;
+			else if (normalizedZoom > maxZoom)
+				normalizedZoom = maxZoom;
+
 			var zoomDeadband = zoomStep > 0f ? zoomStep / 2f : float.Epsilon;
 			if (Math.Abs((float)zoomControl.Value - normalizedZoom) > zoomDeadband)
 				zoomControl.Value = normalizedZoom;

--- a/ZXing.Net.MAUI/Platforms/Windows/CameraManager.windows.cs
+++ b/ZXing.Net.MAUI/Platforms/Windows/CameraManager.windows.cs
@@ -429,6 +429,7 @@ namespace ZXing.Net.Maui
 				_mediaFrameReader.FrameArrived += ColorFrameReader_FrameArrived;
 				await _mediaFrameReader.StartAsync();
 
+				ApplyZoomFactorUnlocked();
 				ShowPreviewBitmap();
 			}
 			catch (Exception ex)
@@ -698,25 +699,7 @@ namespace ZXing.Net.Maui
 
 			try
 			{
-				var zoomControl = _mediaCapture?.VideoDeviceController?.ZoomControl;
-				if (zoomControl?.Supported ?? false)
-				{
-					var minZoom = (float)zoomControl.Min;
-					var maxZoom = (float)zoomControl.Max;
-					if (maxZoom < minZoom)
-						maxZoom = minZoom;
-
-					var normalizedZoom = ZoomFactor * (maxZoom - minZoom) + minZoom;
-					if (normalizedZoom < minZoom)
-						normalizedZoom = minZoom;
-					else if (normalizedZoom > maxZoom)
-						normalizedZoom = maxZoom;
-
-					if (Math.Abs(zoomControl.Value - normalizedZoom) > float.Epsilon)
-					{
-						zoomControl.Value = normalizedZoom;
-					}
-				}
+				ApplyZoomFactorUnlocked();
 			}
 			catch (Exception ex)
 			{
@@ -726,6 +709,29 @@ namespace ZXing.Net.Maui
 			{
 				MediaCaptureLifeLock.Release();
 			}
+		}
+
+		private void ApplyZoomFactorUnlocked()
+		{
+			var zoomControl = _mediaCapture?.VideoDeviceController?.ZoomControl;
+			if (!(zoomControl?.Supported ?? false))
+				return;
+
+			var minZoom = (float)zoomControl.Min;
+			var maxZoom = (float)zoomControl.Max;
+			if (maxZoom < minZoom)
+				maxZoom = minZoom;
+
+			var normalizedZoom = ZoomFactor * (maxZoom - minZoom) + minZoom;
+			if (normalizedZoom < minZoom)
+				normalizedZoom = minZoom;
+			else if (normalizedZoom > maxZoom)
+				normalizedZoom = maxZoom;
+
+			var zoomStep = (float)zoomControl.Step;
+			var zoomDeadband = zoomStep > 0f ? zoomStep / 2f : float.Epsilon;
+			if (Math.Abs((float)zoomControl.Value - normalizedZoom) > zoomDeadband)
+				zoomControl.Value = normalizedZoom;
 		}
 
 		private async Task FocusAsync(Microsoft.Maui.Graphics.Point point)

--- a/ZXing.Net.MAUI/Platforms/Windows/CameraManager.windows.cs
+++ b/ZXing.Net.MAUI/Platforms/Windows/CameraManager.windows.cs
@@ -209,6 +209,11 @@ namespace ZXing.Net.Maui
 
 		public void UpdateTorch(bool on) => TryEnqueueUI(async () => await UpdateTorchAsync(on));
 
+		partial void ApplyZoomFactor()
+		{
+			TryEnqueueUI(async () => await ApplyZoomFactorAsync());
+		}
+
 		public void Focus(Microsoft.Maui.Graphics.Point point) => TryEnqueueUI(async () => await FocusAsync(point));
 
 		public void AutoFocus() => TryEnqueueUI(async () => await AutoFocusAsync());
@@ -674,6 +679,42 @@ namespace ZXing.Net.Maui
 					if (on != bEnabled)
 					{
 						_mediaCapture.VideoDeviceController.TorchControl.Enabled = on;
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine(ex);
+			}
+			finally
+			{
+				MediaCaptureLifeLock.Release();
+			}
+		}
+
+		private async Task ApplyZoomFactorAsync()
+		{
+			await MediaCaptureLifeLock.WaitAsync();
+
+			try
+			{
+				var zoomControl = _mediaCapture?.VideoDeviceController?.ZoomControl;
+				if (zoomControl?.Supported ?? false)
+				{
+					var minZoom = (float)zoomControl.Min;
+					var maxZoom = (float)zoomControl.Max;
+					if (maxZoom < minZoom)
+						maxZoom = minZoom;
+
+					var normalizedZoom = ZoomFactor * (maxZoom - minZoom) + minZoom;
+					if (normalizedZoom < minZoom)
+						normalizedZoom = minZoom;
+					else if (normalizedZoom > maxZoom)
+						normalizedZoom = maxZoom;
+
+					if (Math.Abs(zoomControl.Value - normalizedZoom) > float.Epsilon)
+					{
+						zoomControl.Value = normalizedZoom;
 					}
 				}
 			}

--- a/ZXing.Net.MAUI/Platforms/Windows/CameraManager.windows.cs
+++ b/ZXing.Net.MAUI/Platforms/Windows/CameraManager.windows.cs
@@ -713,33 +713,35 @@ namespace ZXing.Net.Maui
 
 		private void ApplyZoomFactorUnlocked()
 		{
-			var zoomControl = _mediaCapture?.VideoDeviceController?.ZoomControl;
-			if (!(zoomControl?.Supported ?? false))
-				return;
+			try
+			{
+				var zoomControl = _mediaCapture?.VideoDeviceController?.ZoomControl;
+				if (!(zoomControl?.Supported ?? false))
+					return;
 
-			var minZoom = (float)zoomControl.Min;
-			var maxZoom = (float)zoomControl.Max;
-			if (maxZoom < minZoom)
-				maxZoom = minZoom;
+				var minZoom = (double)zoomControl.Min;
+				var maxZoom = (double)zoomControl.Max;
+				if (maxZoom < minZoom)
+					maxZoom = minZoom;
 
-			var normalizedZoom = ZoomFactor * (maxZoom - minZoom) + minZoom;
-			if (normalizedZoom < minZoom)
-				normalizedZoom = minZoom;
-			else if (normalizedZoom > maxZoom)
-				normalizedZoom = maxZoom;
+				var normalizedZoom = (double)ZoomFactor * (maxZoom - minZoom) + minZoom;
+				normalizedZoom = Math.Clamp(normalizedZoom, minZoom, maxZoom);
 
-			var zoomStep = (float)zoomControl.Step;
-			if (zoomStep > 0f)
-				normalizedZoom = (float)Math.Round((normalizedZoom - minZoom) / zoomStep) * zoomStep + minZoom;
+				var zoomStep = (double)zoomControl.Step;
+				if (zoomStep > 0d)
+				{
+					normalizedZoom = Math.Round((normalizedZoom - minZoom) / zoomStep) * zoomStep + minZoom;
+					normalizedZoom = Math.Clamp(normalizedZoom, minZoom, maxZoom);
+				}
 
-			if (normalizedZoom < minZoom)
-				normalizedZoom = minZoom;
-			else if (normalizedZoom > maxZoom)
-				normalizedZoom = maxZoom;
-
-			var zoomDeadband = zoomStep > 0f ? zoomStep / 2f : float.Epsilon;
-			if (Math.Abs((float)zoomControl.Value - normalizedZoom) > zoomDeadband)
-				zoomControl.Value = normalizedZoom;
+				var zoomDeadband = zoomStep > 0d ? zoomStep / 2d : double.Epsilon;
+				if (Math.Abs((double)zoomControl.Value - normalizedZoom) > zoomDeadband)
+					zoomControl.Value = (float)normalizedZoom;
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine(ex);
+			}
 		}
 
 		private async Task FocusAsync(Microsoft.Maui.Graphics.Point point)

--- a/ZXing.Net.MAUI/Platforms/Windows/CameraManager.windows.cs
+++ b/ZXing.Net.MAUI/Platforms/Windows/CameraManager.windows.cs
@@ -209,6 +209,11 @@ namespace ZXing.Net.Maui
 
 		public void UpdateTorch(bool on) => TryEnqueueUI(async () => await UpdateTorchAsync(on));
 
+		partial void ApplyZoomFactor()
+		{
+			TryEnqueueUI(async () => await ApplyZoomFactorAsync());
+		}
+
 		public void Focus(Microsoft.Maui.Graphics.Point point) => TryEnqueueUI(async () => await FocusAsync(point));
 
 		public void AutoFocus() => TryEnqueueUI(async () => await AutoFocusAsync());
@@ -620,6 +625,42 @@ namespace ZXing.Net.Maui
 					if (on != bEnabled)
 					{
 						_mediaCapture.VideoDeviceController.TorchControl.Enabled = on;
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine(ex);
+			}
+			finally
+			{
+				MediaCaptureLifeLock.Release();
+			}
+		}
+
+		private async Task ApplyZoomFactorAsync()
+		{
+			await MediaCaptureLifeLock.WaitAsync();
+
+			try
+			{
+				var zoomControl = _mediaCapture?.VideoDeviceController?.ZoomControl;
+				if (zoomControl?.Supported ?? false)
+				{
+					var minZoom = (float)zoomControl.Min;
+					var maxZoom = (float)zoomControl.Max;
+					if (maxZoom < minZoom)
+						maxZoom = minZoom;
+
+					var normalizedZoom = ZoomFactor * (maxZoom - minZoom) + minZoom;
+					if (normalizedZoom < minZoom)
+						normalizedZoom = minZoom;
+					else if (normalizedZoom > maxZoom)
+						normalizedZoom = maxZoom;
+
+					if (Math.Abs(zoomControl.Value - normalizedZoom) > float.Epsilon)
+					{
+						zoomControl.Value = normalizedZoom;
 					}
 				}
 			}


### PR DESCRIPTION
### Description

- Expose a bindable `ZoomFactor` property for CameraBarcodeReaderView to control camera zooming. 
- Accept a float value [0 - 1] and maps it to each platform's supported zoom range. 
- Ensure platform-specific behavior to avoid engaging digital zoom (iOS capped to optical max) and to use native linear zoom where appropriate. 

### Motivation
There are situations where by using zoom can considerably improve the detectability of Zxing.

### Tests
It was manually tested on physical iOS/Android phones and Windows device with a camera.