### PR TITLE
Add AssumeGS1 flag to barcode reader options

### DIFF
--- a/ZXing.Net.MAUI/BarcodeScannerOptions.cs
+++ b/ZXing.Net.MAUI/BarcodeScannerOptions.cs
@@ -17,5 +17,7 @@
 
 		public string CharacterSet { get; init; } = "UTF-8";
 
+		public bool AssumeGS1 { get; init; }
+
     }
 }

--- a/ZXing.Net.MAUI/ZXingBarcodeReader.cs
+++ b/ZXing.Net.MAUI/ZXingBarcodeReader.cs
@@ -23,6 +23,7 @@
 				zxingReader.Options.TryInverted = options.TryInverted;
 				zxingReader.Options.UseCode39ExtendedMode = options.UseCode39ExtendedMode;
 				zxingReader.Options.CharacterSet = options.CharacterSet;
+                zxingReader.Options.AssumeGS1 = options.AssumeGS1;
 			}
 		}
 

--- a/ZXing.Net.MAUI/ZXingBarcodeReader.cs
+++ b/ZXing.Net.MAUI/ZXingBarcodeReader.cs
@@ -23,7 +23,7 @@
 				zxingReader.Options.TryInverted = options.TryInverted;
 				zxingReader.Options.UseCode39ExtendedMode = options.UseCode39ExtendedMode;
 				zxingReader.Options.CharacterSet = options.CharacterSet;
-                zxingReader.Options.AssumeGS1 = options.AssumeGS1;
+				zxingReader.Options.AssumeGS1 = options.AssumeGS1;
 			}
 		}
 


### PR DESCRIPTION
This PR adds a flag to BarcodeReaderOptions in order to enable the AssumeGS1 setting.
Some barcodes are not scanned properly without the AssumeGS1 option, so this option is now configurable. 