### PR TITLE
Rebase PR #52 Android rotation and autofocus fixes

### DIFF
--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -46,6 +46,7 @@ namespace ZXing.Net.Maui
         private ProcessCameraProvider _cameraProvider;
         private ICamera _camera;
         private System.Threading.Timer _autoFocusTimer;
+        private int _autoFocusTimerGeneration;
         private TapFocusTouchListener _tapFocusTouchListener;
 
         private static readonly Android.Util.Size DefaultResolution = new(640, 480);
@@ -297,11 +298,23 @@ namespace ZXing.Net.Maui
 
         public void Focus(Microsoft.Maui.Graphics.Point point)
         {
+            if (!Microsoft.Maui.ApplicationModel.MainThread.IsMainThread)
+            {
+                Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() => Focus(point));
+                return;
+            }
+
             StartFocusAndMetering((float)point.X, (float)point.Y, disableAutoCancel: true);
         }
 
         public void AutoFocus()
         {
+            if (!Microsoft.Maui.ApplicationModel.MainThread.IsMainThread)
+            {
+                Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(AutoFocus);
+                return;
+            }
+
             if (_previewView == null)
                 return;
 
@@ -343,12 +356,14 @@ namespace ZXing.Net.Maui
         private void StartFocusAndMetering(float x, float y, bool disableAutoCancel)
         {
             var cameraControl = _camera?.CameraControl;
-            if (cameraControl == null || _previewView == null || _previewView.Width <= 0 || _previewView.Height <= 0)
+            var previewView = _previewView;
+
+            if (cameraControl == null || previewView == null || previewView.Width <= 0 || previewView.Height <= 0)
                 return;
 
             cameraControl.CancelFocusAndMetering();
 
-            var meteringPoint = _previewView.MeteringPointFactory.CreatePoint(x, y);
+            var meteringPoint = previewView.MeteringPointFactory.CreatePoint(x, y);
             var actionBuilder = new FocusMeteringAction.Builder(meteringPoint, FocusMeteringAction.FlagAf);
 
             if (disableAutoCancel)
@@ -360,11 +375,21 @@ namespace ZXing.Net.Maui
         private void StartAutoFocusTimer()
         {
             StopAutoFocusTimer();
-            _autoFocusTimer = new System.Threading.Timer(_ => AutoFocus(), null, System.TimeSpan.FromSeconds(5), System.TimeSpan.FromSeconds(5));
+
+            var generation = System.Threading.Interlocked.Increment(ref _autoFocusTimerGeneration);
+            _autoFocusTimer = new System.Threading.Timer(_ =>
+            {
+                Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() =>
+                {
+                    if (_autoFocusTimer != null && generation == System.Threading.Volatile.Read(ref _autoFocusTimerGeneration))
+                        AutoFocus();
+                });
+            }, null, System.TimeSpan.FromSeconds(5), System.TimeSpan.FromSeconds(5));
         }
 
         private void StopAutoFocusTimer()
         {
+            System.Threading.Interlocked.Increment(ref _autoFocusTimerGeneration);
             _autoFocusTimer?.Dispose();
             _autoFocusTimer = null;
         }

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -223,6 +223,7 @@ namespace ZXing.Net.Maui
             _imageAnalyzer = new ImageAnalysis
                 .Builder()
                 .SetOutputImageFormat(ImageAnalysis.OutputImageFormatRgba8888)
+                .SetOutputImageRotationEnabled(true)
                 .SetResolutionSelector(_resolutionSelector)
                 .SetBackpressureStrategy(ImageAnalysis.StrategyKeepOnlyLatest)
                 .Build();

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -47,12 +47,15 @@ namespace ZXing.Net.Maui
         private ICamera _camera;
         private System.Threading.Timer _autoFocusTimer;
         private int _autoFocusTimerGeneration;
+        private bool _isCameraBound;
+        private bool _isDisposed;
         private TapFocusTouchListener _tapFocusTouchListener;
 
         private static readonly Android.Util.Size DefaultResolution = new(640, 480);
 
         public NativePlatformCameraPreviewView CreateNativeView()
         {
+            System.Threading.Volatile.Write(ref _isDisposed, false);
             _previewView = new PreviewView(Context.Context);
             _tapFocusTouchListener = new TapFocusTouchListener(this);
             _previewView.SetOnTouchListener(_tapFocusTouchListener);
@@ -79,6 +82,7 @@ namespace ZXing.Net.Maui
 
         public void Disconnect()
         {
+            System.Threading.Volatile.Write(ref _isCameraBound, false);
             StopAutoFocusTimer();
             _cameraProvider?.UnbindAll();
             _cameraExecutor?.Shutdown();
@@ -88,6 +92,9 @@ namespace ZXing.Net.Maui
         {
             if (_cameraProvider != null)
             {
+                System.Threading.Volatile.Write(ref _isCameraBound, false);
+                StopAutoFocusTimer();
+
                 // Unbind use cases before rebinding
                 _cameraProvider.UnbindAll();
 
@@ -148,8 +155,12 @@ namespace ZXing.Net.Maui
                     _camera = _cameraProvider.BindToLifecycle(maLifecycleOwner, _cameraSelector, _cameraPreview, _imageAnalyzer);
                 }
 
-                AutoFocus();
-                StartAutoFocusTimer();
+                if (_camera != null && !System.Threading.Volatile.Read(ref _isDisposed))
+                {
+                    System.Threading.Volatile.Write(ref _isCameraBound, true);
+                    AutoFocus();
+                    StartAutoFocusTimer();
+                }
             }
         }
 
@@ -298,6 +309,9 @@ namespace ZXing.Net.Maui
 
         public void Focus(Microsoft.Maui.Graphics.Point point)
         {
+            if (System.Threading.Volatile.Read(ref _isDisposed))
+                return;
+
             if (!Microsoft.Maui.ApplicationModel.MainThread.IsMainThread)
             {
                 Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() => Focus(point));
@@ -309,6 +323,9 @@ namespace ZXing.Net.Maui
 
         public void AutoFocus()
         {
+            if (System.Threading.Volatile.Read(ref _isDisposed))
+                return;
+
             if (!Microsoft.Maui.ApplicationModel.MainThread.IsMainThread)
             {
                 Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(AutoFocus);
@@ -323,6 +340,8 @@ namespace ZXing.Net.Maui
 
         public void Dispose()
         {
+            System.Threading.Volatile.Write(ref _isDisposed, true);
+            System.Threading.Volatile.Write(ref _isCameraBound, false);
             StopAutoFocusTimer();
 
             _imageAnalyzer?.Dispose();
@@ -355,6 +374,9 @@ namespace ZXing.Net.Maui
 
         private void StartFocusAndMetering(float x, float y, bool disableAutoCancel)
         {
+            if (System.Threading.Volatile.Read(ref _isDisposed) || !System.Threading.Volatile.Read(ref _isCameraBound))
+                return;
+
             var cameraControl = _camera?.CameraControl;
             var previewView = _previewView;
 
@@ -381,8 +403,13 @@ namespace ZXing.Net.Maui
             {
                 Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() =>
                 {
-                    if (_autoFocusTimer != null && generation == System.Threading.Volatile.Read(ref _autoFocusTimerGeneration))
+                    if (_autoFocusTimer != null
+                        && generation == System.Threading.Volatile.Read(ref _autoFocusTimerGeneration)
+                        && !System.Threading.Volatile.Read(ref _isDisposed)
+                        && System.Threading.Volatile.Read(ref _isCameraBound))
+                    {
                         AutoFocus();
+                    }
                 });
             }, null, System.TimeSpan.FromSeconds(5), System.TimeSpan.FromSeconds(5));
         }

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -402,7 +402,7 @@ namespace ZXing.Net.Maui
             var cameraControl = _camera?.CameraControl;
             var previewView = _previewView;
 
-            if (cameraControl == null || previewView == null || previewView.Width <= 0 || previewView.Height <= 0)
+            if (cameraControl == null || previewView == null || !previewView.IsAttachedToWindow || previewView.Width <= 0 || previewView.Height <= 0)
                 return;
 
             cameraControl.CancelFocusAndMetering();
@@ -425,8 +425,7 @@ namespace ZXing.Net.Maui
             {
                 Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(() =>
                 {
-                    if (_autoFocusTimer != null
-                        && generation == System.Threading.Volatile.Read(ref _autoFocusTimerGeneration)
+                    if (generation == System.Threading.Volatile.Read(ref _autoFocusTimerGeneration)
                         && !System.Threading.Volatile.Read(ref _isDisposed)
                         && System.Threading.Volatile.Read(ref _isCameraBound))
                     {

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -46,6 +46,7 @@ namespace ZXing.Net.Maui
         private ProcessCameraProvider _cameraProvider;
         private ICamera _camera;
         private System.Threading.Timer _autoFocusTimer;
+        private int _connectGeneration;
         private int _autoFocusTimerGeneration;
         private bool _isCameraBound;
         private bool _isDisposed;
@@ -66,22 +67,37 @@ namespace ZXing.Net.Maui
 
         public void Connect()
         {
+            var connectGeneration = System.Threading.Interlocked.Increment(ref _connectGeneration);
             var cameraProviderFuture = ProcessCameraProvider.GetInstance(Context.Context);
 
             cameraProviderFuture.AddListener(new Java.Lang.Runnable(() =>
             {
+                if (!IsConnectGenerationCurrent(connectGeneration))
+                    return;
+
+                var previewView = _previewView;
+                var cameraExecutor = _cameraExecutor;
+                if (previewView == null || cameraExecutor == null)
+                    return;
+
                 // Used to bind the lifecycle of cameras to the lifecycle owner
-                _cameraProvider = (ProcessCameraProvider)cameraProviderFuture.Get();
+                var cameraProvider = (ProcessCameraProvider)cameraProviderFuture.Get();
+                if (!IsConnectGenerationCurrent(connectGeneration))
+                    return;
 
-                ConfigureUseCases();
+                _cameraProvider = cameraProvider;
 
-                UpdateCamera();
+                ConfigureUseCases(cameraExecutor, previewView);
+
+                if (IsConnectGenerationCurrent(connectGeneration))
+                    UpdateCamera();
 
             }), ContextCompat.GetMainExecutor(Context.Context)); //GetMainExecutor: returns an Executor that runs on the main thread.
         }
 
         public void Disconnect()
         {
+            System.Threading.Interlocked.Increment(ref _connectGeneration);
             System.Threading.Volatile.Write(ref _isCameraBound, false);
             StopAutoFocusTimer();
             _cameraProvider?.UnbindAll();
@@ -219,12 +235,17 @@ namespace ZXing.Net.Maui
             if (_cameraProvider == null)
                 return;
 
+            var previewView = _previewView;
+            var cameraExecutor = _cameraExecutor;
+            if (previewView == null || cameraExecutor == null)
+                return;
+
             _cameraProvider.UnbindAll();
-            ConfigureUseCases();
+            ConfigureUseCases(cameraExecutor, previewView);
             UpdateCamera();
         }
 
-        void ConfigureUseCases()
+        void ConfigureUseCases(IExecutorService cameraExecutor, PreviewView previewView)
         {
             _resolutionSelector?.Dispose();
             _resolutionSelector = CreateResolutionSelector();
@@ -235,7 +256,7 @@ namespace ZXing.Net.Maui
                 .SetResolutionSelector(_resolutionSelector)
                 .Build();
 
-            _cameraPreview.SetSurfaceProvider(_cameraExecutor, _previewView.SurfaceProvider);
+            _cameraPreview.SetSurfaceProvider(cameraExecutor, previewView.SurfaceProvider);
 
             _imageAnalyzer?.Dispose();
             _imageAnalyzer = new ImageAnalysis
@@ -246,7 +267,7 @@ namespace ZXing.Net.Maui
                 .SetBackpressureStrategy(ImageAnalysis.StrategyKeepOnlyLatest)
                 .Build();
 
-            _imageAnalyzer.SetAnalyzer(_cameraExecutor, new FrameAnalyzer((buffer, size) =>
+            _imageAnalyzer.SetAnalyzer(cameraExecutor, new FrameAnalyzer((buffer, size) =>
                 FrameReady?.Invoke(this, new CameraFrameBufferEventArgs(new Readers.PixelBufferHolder { Data = buffer, Size = size }))));
         }
 
@@ -340,6 +361,7 @@ namespace ZXing.Net.Maui
 
         public void Dispose()
         {
+            System.Threading.Interlocked.Increment(ref _connectGeneration);
             System.Threading.Volatile.Write(ref _isDisposed, true);
             System.Threading.Volatile.Write(ref _isCameraBound, false);
             StopAutoFocusTimer();
@@ -420,6 +442,10 @@ namespace ZXing.Net.Maui
             _autoFocusTimer?.Dispose();
             _autoFocusTimer = null;
         }
+
+        private bool IsConnectGenerationCurrent(int generation)
+            => generation == System.Threading.Volatile.Read(ref _connectGeneration)
+                && !System.Threading.Volatile.Read(ref _isDisposed);
 
         private sealed class TapFocusTouchListener : Java.Lang.Object, Android.Views.View.IOnTouchListener
         {

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -4,8 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
-using Android.Graphics;
-
 using AndroidX.Camera.Core;
 using AndroidX.Camera.Core.ResolutionSelector;
 using AndroidX.Camera.Lifecycle;
@@ -47,12 +45,16 @@ namespace ZXing.Net.Maui
         private CameraSelector _cameraSelector = null;
         private ProcessCameraProvider _cameraProvider;
         private ICamera _camera;
+        private System.Threading.Timer _autoFocusTimer;
+        private TapFocusTouchListener _tapFocusTouchListener;
 
         private static readonly Android.Util.Size DefaultResolution = new(640, 480);
 
         public NativePlatformCameraPreviewView CreateNativeView()
         {
             _previewView = new PreviewView(Context.Context);
+            _tapFocusTouchListener = new TapFocusTouchListener(this);
+            _previewView.SetOnTouchListener(_tapFocusTouchListener);
             _cameraExecutor = Executors.NewSingleThreadExecutor();
 
             return _previewView;
@@ -76,6 +78,7 @@ namespace ZXing.Net.Maui
 
         public void Disconnect()
         {
+            StopAutoFocusTimer();
             _cameraProvider?.UnbindAll();
             _cameraExecutor?.Shutdown();
         }
@@ -143,6 +146,9 @@ namespace ZXing.Net.Maui
                     // if not, this should be sufficient as a fallback
                     _camera = _cameraProvider.BindToLifecycle(maLifecycleOwner, _cameraSelector, _cameraPreview, _imageAnalyzer);
                 }
+
+                AutoFocus();
+                StartAutoFocusTimer();
             }
         }
 
@@ -289,18 +295,23 @@ namespace ZXing.Net.Maui
             }
         }
 
-        public void Focus(Point point)
+        public void Focus(Microsoft.Maui.Graphics.Point point)
         {
-
+            StartFocusAndMetering((float)point.X, (float)point.Y, disableAutoCancel: true);
         }
 
         public void AutoFocus()
         {
+            if (_previewView == null)
+                return;
 
+            StartFocusAndMetering(_previewView.Width / 2f, _previewView.Height / 2f, disableAutoCancel: false);
         }
 
         public void Dispose()
         {
+            StopAutoFocusTimer();
+
             _imageAnalyzer?.Dispose();
             _imageAnalyzer = null;
 
@@ -319,11 +330,62 @@ namespace ZXing.Net.Maui
             _previewView?.Dispose();
             _previewView = null;
 
+            _tapFocusTouchListener?.Dispose();
+            _tapFocusTouchListener = null;
+
             _cameraExecutor?.Dispose();
             _cameraExecutor = null;
 
             _camera?.Dispose();
             _camera = null;
+        }
+
+        private void StartFocusAndMetering(float x, float y, bool disableAutoCancel)
+        {
+            var cameraControl = _camera?.CameraControl;
+            if (cameraControl == null || _previewView == null || _previewView.Width <= 0 || _previewView.Height <= 0)
+                return;
+
+            cameraControl.CancelFocusAndMetering();
+
+            var meteringPoint = _previewView.MeteringPointFactory.CreatePoint(x, y);
+            var actionBuilder = new FocusMeteringAction.Builder(meteringPoint, FocusMeteringAction.FlagAf);
+
+            if (disableAutoCancel)
+                actionBuilder.DisableAutoCancel();
+
+            cameraControl.StartFocusAndMetering(actionBuilder.Build());
+        }
+
+        private void StartAutoFocusTimer()
+        {
+            StopAutoFocusTimer();
+            _autoFocusTimer = new System.Threading.Timer(_ => AutoFocus(), null, System.TimeSpan.FromSeconds(5), System.TimeSpan.FromSeconds(5));
+        }
+
+        private void StopAutoFocusTimer()
+        {
+            _autoFocusTimer?.Dispose();
+            _autoFocusTimer = null;
+        }
+
+        private sealed class TapFocusTouchListener : Java.Lang.Object, Android.Views.View.IOnTouchListener
+        {
+            private readonly CameraManager _cameraManager;
+
+            public TapFocusTouchListener(CameraManager cameraManager)
+            {
+                _cameraManager = cameraManager;
+            }
+
+            public bool OnTouch(Android.Views.View view, Android.Views.MotionEvent e)
+            {
+                if (e.Action != Android.Views.MotionEventActions.Down)
+                    return false;
+
+                _cameraManager.Focus(new Microsoft.Maui.Graphics.Point(e.GetX(), e.GetY()));
+                return true;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Rebased the original PR #52 commits onto current `main`, preserving Chris Walker's original author attribution
- Kept the Android `ImageAnalysis` output rotation fix for 1D barcode scanning
- Modernized Android tap-to-focus and periodic autofocus on top of the current camera manager implementation
- Added main-thread and teardown guards for autofocus callbacks after code review

## Validation
- `dotnet restore ZXing.Net.MAUI.sln`
- `dotnet build ZXing.Net.MAUI\ZXing.Net.MAUI.csproj -f net10.0-android --no-restore -m:1`

Note: the Android library build succeeds with the existing CS8632 nullable annotation warning in `CameraManager.android.cs`.