### PR TITLE
Add scanner timing and resolution options

### DIFF
--- a/BigIslandBarcode/MainPage.xaml.cs
+++ b/BigIslandBarcode/MainPage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
@@ -17,8 +18,23 @@ namespace BigIslandBarcode
 			{
 				Formats = BarcodeFormats.All,
 				AutoRotate = true,
-				Multiple = true
+				Multiple = true,
+				DelayBetweenAnalyzingFrames = 150,
+				InitialDelayBeforeAnalyzingFrames = 300,
+				DelayBetweenContinuousScans = 1000,
+				CameraResolutionSelector = SelectCameraResolution
 			};
+		}
+
+		static CameraResolution SelectCameraResolution(IReadOnlyList<CameraResolution> availableResolutions)
+		{
+			if (availableResolutions.Count == 0)
+				return new CameraResolution(640, 480);
+
+			return availableResolutions
+				.OrderBy(resolution => Math.Abs((resolution.Width * resolution.Height) - (1280 * 720)))
+				.ThenBy(resolution => Math.Abs(resolution.Width - 1280) + Math.Abs(resolution.Height - 720))
+				.First();
 		}
 
 		protected void BarcodesDetected(object sender, BarcodeDetectionEventArgs e)

--- a/README.md
+++ b/README.md
@@ -90,9 +90,19 @@ cameraBarcodeReaderView.Options = new BarcodeReaderOptions
 {
   Formats = BarcodeFormats.OneDimensional,
   AutoRotate = true,
-  Multiple = true
+  Multiple = true,
+  DelayBetweenAnalyzingFrames = 150,
+  InitialDelayBeforeAnalyzingFrames = 300,
+  DelayBetweenContinuousScans = 1000,
+  CameraResolutionSelector = availableResolutions =>
+    availableResolutions
+      .OrderBy(resolution => Math.Abs((resolution.Width * resolution.Height) - (1280 * 720)))
+      .ThenBy(resolution => Math.Abs(resolution.Width - 1280) + Math.Abs(resolution.Height - 720))
+      .First()
 };
 ```
+
+The delay options are expressed in milliseconds and default to the Xamarin plugin cadence: `150` milliseconds between frame analyses, `300` milliseconds before initial analysis, and `1000` milliseconds between continuous scan detections. Set a delay to `0` to analyze as soon as the camera pipeline provides frames. `CameraResolutionSelector` receives the resolutions supported by the active camera and should return the preferred resolution.
 
 QR codes with international characters (e.g., £, €, ¥, or non-Latin scripts) are supported by default with UTF-8 encoding. You can override this if needed:
 ```csharp
@@ -172,7 +182,5 @@ The `BarcodeGeneratorView` supports UTF-8 character encoding by default, which a
 ```
 
 The `CharacterSet` property defaults to "UTF-8" if not specified. Other common values include "ISO-8859-1", "Shift_JIS", etc., depending on your barcode format requirements.
-
-
 
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ cameraBarcodeReaderView.Options = new BarcodeReaderOptions
 
 The delay options are expressed in milliseconds and default to the Xamarin plugin cadence: `150` milliseconds between frame analyses, `300` milliseconds before initial analysis, and `1000` milliseconds between continuous scan detections. Set a delay to `0` to analyze as soon as the camera pipeline provides frames. `CameraResolutionSelector` receives the resolutions supported by the active camera and should return the preferred resolution.
 
+The selected camera resolution is also the frame size passed to the barcode decoder. Higher resolutions provide more pixels but increase the amount of work needed for every frame, so selecting the largest available resolution can reduce scan throughput. Prefer the lowest resolution that reliably decodes for your use case, such as a size close to `1280x720` or `640x480`, instead of always ordering by the highest pixel count.
+
 QR codes with international characters (e.g., £, €, ¥, or non-Latin scripts) are supported by default with UTF-8 encoding. You can override this if needed:
 ```csharp
 cameraBarcodeReaderView.Options = new BarcodeReaderOptions
@@ -182,5 +184,4 @@ The `BarcodeGeneratorView` supports UTF-8 character encoding by default, which a
 ```
 
 The `CharacterSet` property defaults to "UTF-8" if not specified. Other common values include "ISO-8859-1", "Shift_JIS", etc., depending on your barcode format requirements.
-
 

--- a/ZXing.Net.MAUI.Tests/BarcodeReaderOptionsTests.cs
+++ b/ZXing.Net.MAUI.Tests/BarcodeReaderOptionsTests.cs
@@ -1,0 +1,58 @@
+using System.Runtime.CompilerServices;
+using ZXing.Net.Maui;
+
+namespace ZXing.Net.MAUI.Tests;
+
+public class BarcodeReaderOptionsTests
+{
+	[Fact]
+	public void DefaultsMatchXamarinScannerCadence()
+	{
+		var options = new BarcodeReaderOptions();
+
+		Assert.Equal(150, options.DelayBetweenAnalyzingFrames);
+		Assert.Equal(1000, options.DelayBetweenContinuousScans);
+		Assert.Equal(300, options.InitialDelayBeforeAnalyzingFrames);
+		Assert.Null(options.CameraResolutionSelector);
+	}
+
+	[Fact]
+	public void DelayPropertiesRejectNegativeValues()
+	{
+		Assert.Throws<ArgumentOutOfRangeException>(() => new BarcodeReaderOptions { DelayBetweenAnalyzingFrames = -1 });
+		Assert.Throws<ArgumentOutOfRangeException>(() => new BarcodeReaderOptions { DelayBetweenContinuousScans = -1 });
+		Assert.Throws<ArgumentOutOfRangeException>(() => new BarcodeReaderOptions { InitialDelayBeforeAnalyzingFrames = -1 });
+	}
+
+	[Theory]
+	[InlineData(nameof(BarcodeReaderOptions.DelayBetweenAnalyzingFrames))]
+	[InlineData(nameof(BarcodeReaderOptions.DelayBetweenContinuousScans))]
+	[InlineData(nameof(BarcodeReaderOptions.InitialDelayBeforeAnalyzingFrames))]
+	[InlineData(nameof(BarcodeReaderOptions.CameraResolutionSelector))]
+	public void ScannerOptionPropertiesAreInitOnly(string propertyName)
+	{
+		var setMethod = typeof(BarcodeReaderOptions).GetProperty(propertyName)!.SetMethod;
+
+		Assert.NotNull(setMethod);
+		Assert.Contains(typeof(IsExternalInit), setMethod.ReturnParameter.GetRequiredCustomModifiers());
+	}
+
+	[Fact]
+	public void CameraResolutionSelectorReceivesAvailableResolutions()
+	{
+		var expected = new CameraResolution(1280, 720);
+		var options = new BarcodeReaderOptions
+		{
+			CameraResolutionSelector = availableResolutions => availableResolutions.Single(resolution =>
+				resolution.Width == expected.Width && resolution.Height == expected.Height)
+		};
+
+		var selected = options.CameraResolutionSelector([
+			new CameraResolution(640, 480),
+			expected,
+			new CameraResolution(1920, 1080)
+		]);
+
+		Assert.Same(expected, selected);
+	}
+}

--- a/ZXing.Net.MAUI.Tests/CameraManagerTests.cs
+++ b/ZXing.Net.MAUI.Tests/CameraManagerTests.cs
@@ -1,0 +1,45 @@
+using ZXing.Net.Maui;
+
+namespace ZXing.Net.MAUI.Tests;
+
+public class CameraManagerTests
+{
+	[Fact]
+	public void ShouldApplyCameraOptionsIgnoresDelayOnlyChanges()
+	{
+		var currentOptions = new BarcodeReaderOptions();
+		var nextOptions = new BarcodeReaderOptions
+		{
+			DelayBetweenAnalyzingFrames = 1,
+			DelayBetweenContinuousScans = 2,
+			InitialDelayBeforeAnalyzingFrames = 3
+		};
+
+		Assert.False(CameraManager.ShouldApplyCameraOptions(currentOptions, nextOptions));
+	}
+
+	[Fact]
+	public void ShouldApplyCameraOptionsReappliesOnlyWhenSelectorChanges()
+	{
+		CameraResolutionSelectorDelegate selector = availableResolutions => availableResolutions.FirstOrDefault();
+		CameraResolutionSelectorDelegate otherSelector = availableResolutions => availableResolutions.LastOrDefault();
+		var noSelectorOptions = new BarcodeReaderOptions();
+		var selectorOptions = new BarcodeReaderOptions
+		{
+			CameraResolutionSelector = selector
+		};
+		var sameSelectorOptions = new BarcodeReaderOptions
+		{
+			CameraResolutionSelector = selector
+		};
+		var otherSelectorOptions = new BarcodeReaderOptions
+		{
+			CameraResolutionSelector = otherSelector
+		};
+
+		Assert.True(CameraManager.ShouldApplyCameraOptions(noSelectorOptions, selectorOptions));
+		Assert.True(CameraManager.ShouldApplyCameraOptions(selectorOptions, noSelectorOptions));
+		Assert.False(CameraManager.ShouldApplyCameraOptions(selectorOptions, sameSelectorOptions));
+		Assert.True(CameraManager.ShouldApplyCameraOptions(selectorOptions, otherSelectorOptions));
+	}
+}

--- a/ZXing.Net.MAUI.Tests/ScannerTimingGateTests.cs
+++ b/ZXing.Net.MAUI.Tests/ScannerTimingGateTests.cs
@@ -1,0 +1,151 @@
+using ZXing.Net.Maui;
+
+namespace ZXing.Net.MAUI.Tests;
+
+public class ScannerTimingGateTests
+{
+	long now;
+
+	[Fact]
+	public void ZeroDelayOptionsAllowEveryCompletedFrame()
+	{
+		var gate = CreateGate(CreateOptions());
+
+		Assert.True(gate.ShouldAnalyze());
+		gate.NotifyAnalyzed();
+		Assert.True(gate.ShouldAnalyze());
+	}
+
+	[Fact]
+	public void InitialDelayBlocksAnalysisUntilElapsed()
+	{
+		var gate = CreateGate(CreateOptions(initialDelayBeforeAnalyzingFrames: 300));
+		gate.StartInitialDelay();
+
+		Assert.False(gate.ShouldAnalyze());
+
+		Advance(299);
+		Assert.False(gate.ShouldAnalyze());
+
+		Advance(1);
+		Assert.True(gate.ShouldAnalyze());
+	}
+
+	[Fact]
+	public void InitialDelayStartsWhenScanningStarts()
+	{
+		var gate = CreateGate(CreateOptions(initialDelayBeforeAnalyzingFrames: 300));
+		gate.StartInitialDelay();
+
+		Advance(1_000);
+
+		Assert.True(gate.ShouldAnalyze());
+	}
+
+	[Fact]
+	public void DelayBetweenAnalyzingFramesThrottlesDecodeAttempts()
+	{
+		var gate = CreateGate(CreateOptions(delayBetweenAnalyzingFrames: 150));
+
+		Assert.True(gate.ShouldAnalyze());
+		Advance(10);
+		gate.NotifyAnalyzed();
+
+		Advance(149);
+		Assert.False(gate.ShouldAnalyze());
+
+		Advance(1);
+		Assert.True(gate.ShouldAnalyze());
+	}
+
+	[Fact]
+	public void DelayBetweenContinuousScansBlocksAnalysisAfterDetection()
+	{
+		var gate = CreateGate(CreateOptions(delayBetweenContinuousScans: 1000));
+
+		Assert.True(gate.ShouldAnalyze());
+		gate.NotifyAnalyzed(detected: true);
+
+		Assert.False(gate.ShouldAnalyze());
+
+		Advance(999);
+		Assert.False(gate.ShouldAnalyze());
+
+		Advance(1);
+		Assert.True(gate.ShouldAnalyze());
+	}
+
+	[Fact]
+	public void ResetRestartsInitialDelay()
+	{
+		var gate = CreateGate(CreateOptions(initialDelayBeforeAnalyzingFrames: 300));
+		gate.StartInitialDelay();
+
+		Assert.False(gate.ShouldAnalyze());
+
+		Advance(300);
+		Assert.True(gate.ShouldAnalyze());
+		gate.NotifyAnalyzed();
+
+		gate.Reset();
+		gate.StartInitialDelay();
+
+		Advance(299);
+		Assert.False(gate.ShouldAnalyze());
+
+		Advance(1);
+		Assert.True(gate.ShouldAnalyze());
+	}
+
+	[Fact]
+	public void AnalysisDelayStartsAfterAnalysisCompletes()
+	{
+		var gate = CreateGate(CreateOptions(delayBetweenAnalyzingFrames: 150));
+
+		Assert.True(gate.ShouldAnalyze());
+
+		Advance(1_000);
+		Assert.False(gate.ShouldAnalyze());
+
+		gate.NotifyAnalyzed();
+		Advance(149);
+		Assert.False(gate.ShouldAnalyze());
+
+		Advance(1);
+		Assert.True(gate.ShouldAnalyze());
+	}
+
+	[Fact]
+	public void ResetClearsInProgressAnalysis()
+	{
+		var gate = CreateGate(CreateOptions());
+
+		Assert.True(gate.ShouldAnalyze());
+		Assert.False(gate.ShouldAnalyze());
+
+		gate.Reset();
+
+		Assert.True(gate.ShouldAnalyze());
+	}
+
+	ScannerTimingGate CreateGate(BarcodeReaderOptions? options = null)
+	{
+		var gate = new ScannerTimingGate(() => now);
+		gate.UpdateOptions(options ?? CreateOptions());
+		return gate;
+	}
+
+	static BarcodeReaderOptions CreateOptions(
+		int delayBetweenAnalyzingFrames = 0,
+		int delayBetweenContinuousScans = 0,
+		int initialDelayBeforeAnalyzingFrames = 0)
+		=> new()
+		{
+			DelayBetweenAnalyzingFrames = delayBetweenAnalyzingFrames,
+			DelayBetweenContinuousScans = delayBetweenContinuousScans,
+			InitialDelayBeforeAnalyzingFrames = initialDelayBeforeAnalyzingFrames
+		};
+
+	void Advance(long milliseconds)
+		=> now += milliseconds;
+}

--- a/ZXing.Net.MAUI.Tests/ZXing.Net.MAUI.Tests.csproj
+++ b/ZXing.Net.MAUI.Tests/ZXing.Net.MAUI.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ZXing.Net.MAUI\ZXing.Net.MAUI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/ZXing.Net.MAUI.sln
+++ b/ZXing.Net.MAUI.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BigIslandBarcode", "BigIsla
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZXing.Net.MAUI.Controls", "ZXing.Net.MAUI.Controls\ZXing.Net.MAUI.Controls.csproj", "{F7911DCB-5278-4CE9-A934-48089F92162A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZXing.Net.MAUI.Tests", "ZXing.Net.MAUI.Tests\ZXing.Net.MAUI.Tests.csproj", "{7FCA1213-010F-4DE7-817B-5746F83CE81A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,6 +30,10 @@ Global
 		{F7911DCB-5278-4CE9-A934-48089F92162A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F7911DCB-5278-4CE9-A934-48089F92162A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F7911DCB-5278-4CE9-A934-48089F92162A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7FCA1213-010F-4DE7-817B-5746F83CE81A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7FCA1213-010F-4DE7-817B-5746F83CE81A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7FCA1213-010F-4DE7-817B-5746F83CE81A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7FCA1213-010F-4DE7-817B-5746F83CE81A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ZXing.Net.MAUI/Apple/CameraManager.ios.maccatalyst.cs
+++ b/ZXing.Net.MAUI/Apple/CameraManager.ios.maccatalyst.cs
@@ -7,6 +7,7 @@ using Foundation;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using UIKit;
 using MSize = Microsoft.Maui.Graphics.Size;
@@ -72,7 +73,7 @@ namespace ZXing.Net.Maui
 
 		public void Connect()
 		{
-			UpdateCamera();
+			UpdateCamera(startIfStopped: true);
 
 			if (videoDataOutput == null)
 			{
@@ -108,112 +109,183 @@ namespace ZXing.Net.Maui
 		}
 
 		public void UpdateCamera()
+			=> UpdateCamera(startIfStopped: false);
+
+		void UpdateCamera(bool startIfStopped)
 		{
 			if (captureSession != null)
 			{
-				if (captureSession.Running)
+				var wasRunning = captureSession.Running;
+				if (wasRunning)
 					captureSession.StopRunning();
 
-				// Cleanup old input
-				if (captureInput != null && captureSession.Inputs.Length > 0 && captureSession.Inputs.Contains(captureInput))
+				captureSession.BeginConfiguration();
+				try
 				{
-					captureSession.RemoveInput(captureInput);
-					captureInput.Dispose();
-					captureInput = null;
-				}
-
-				// Cleanup old device
-				if (captureDevice != null)
-				{
-					captureDevice.Dispose();
-					captureDevice = null;
-				}
-
-				// If a specific camera is selected, use it
-				if (SelectedCamera != null)
-				{
-					captureDevice = AVCaptureDevice.GetDefaultDevice(AVMediaTypes.Video);
-					var discoverySession = AVCaptureDeviceDiscoverySession.Create(CaptureDevices(), AVMediaTypes.Video, AVCaptureDevicePosition.Unspecified);
-					foreach (var device in discoverySession.Devices)
+					// Cleanup old input
+					if (captureInput != null && captureSession.Inputs.Length > 0 && captureSession.Inputs.Contains(captureInput))
 					{
-						if (device.UniqueID == SelectedCamera.DeviceId)
-						{
-							captureDevice = device;
-							break;
-						}
+						captureSession.RemoveInput(captureInput);
+						captureInput.Dispose();
+						captureInput = null;
 					}
-				}
-				else
-				{
-					var discoverySession = AVCaptureDeviceDiscoverySession.Create(CaptureDevices(), AVMediaTypes.Video, AVCaptureDevicePosition.Unspecified);
-					
-					// Prioritize cameras suitable for barcode scanning
-					AVCaptureDevice selectedDevice = null;
-					AVCaptureDevice fallbackDevice = null;
-					
-					foreach (var device in discoverySession.Devices)
-					{
-						// Skip depth-only cameras (TrueDepth, LiDAR) as they're not suitable for barcode scanning
-						if (device.DeviceType == AVCaptureDeviceType.BuiltInTrueDepthCamera ||
-							device.DeviceType == AVCaptureDeviceType.BuiltInLiDarDepthCamera)
-							continue;
-						
-						var isCorrectPosition = (CameraLocation == CameraLocation.Front && device.Position == AVCaptureDevicePosition.Front) ||
-												(CameraLocation == CameraLocation.Rear && device.Position == AVCaptureDevicePosition.Back);
-						
-						if (isCorrectPosition)
-						{
-							// Prefer multi-camera systems (Dual, Triple, DualWide) - these are the main cameras on modern iPhones
-							if (device.DeviceType == AVCaptureDeviceType.BuiltInDualCamera ||
-								device.DeviceType == AVCaptureDeviceType.BuiltInTripleCamera ||
-								device.DeviceType == AVCaptureDeviceType.BuiltInDualWideCamera)
-							{
-								selectedDevice = device;
-								break; // Multi-camera systems are ideal for barcode scanning
-							}
-							// Wide-angle is a good standard camera
-							else if (device.DeviceType == AVCaptureDeviceType.BuiltInWideAngleCamera && selectedDevice == null)
-							{
-								selectedDevice = device;
-							}
-							// Avoid ultra-wide and telephoto, but keep as last resort fallback
-							else if (fallbackDevice == null)
-							{
-								fallbackDevice = device;
-							}
-						}
-					}
-					
-					// Use selected device, or fallback if nothing better was found
-					captureDevice = selectedDevice ?? fallbackDevice;
 
-					if (captureDevice == null)
+					// Cleanup old device
+					if (captureDevice != null)
+					{
+						captureDevice.Dispose();
+						captureDevice = null;
+					}
+
+					// If a specific camera is selected, use it
+					if (SelectedCamera != null)
+					{
 						captureDevice = AVCaptureDevice.GetDefaultDevice(AVMediaTypes.Video);
-				}
+						var discoverySession = AVCaptureDeviceDiscoverySession.Create(CaptureDevices(), AVMediaTypes.Video, AVCaptureDevicePosition.Unspecified);
+						foreach (var device in discoverySession.Devices)
+						{
+							if (device.UniqueID == SelectedCamera.DeviceId)
+							{
+								captureDevice = device;
+								break;
+							}
+						}
+					}
+					else
+					{
+						var discoverySession = AVCaptureDeviceDiscoverySession.Create(CaptureDevices(), AVMediaTypes.Video, AVCaptureDevicePosition.Unspecified);
+						
+						// Prioritize cameras suitable for barcode scanning
+						AVCaptureDevice selectedDevice = null;
+						AVCaptureDevice fallbackDevice = null;
 
-				if (captureDevice is null)
-					return;
+						foreach (var device in discoverySession.Devices)
+						{
+							// Skip depth-only cameras (TrueDepth, LiDAR) as they're not suitable for barcode scanning
+							if (device.DeviceType == AVCaptureDeviceType.BuiltInTrueDepthCamera ||
+								device.DeviceType == AVCaptureDeviceType.BuiltInLiDarDepthCamera)
+								continue;
 
-				captureInput = new AVCaptureDeviceInput(captureDevice, out var err);
+							var isCorrectPosition = (CameraLocation == CameraLocation.Front && device.Position == AVCaptureDevicePosition.Front) ||
+													(CameraLocation == CameraLocation.Rear && device.Position == AVCaptureDevicePosition.Back);
 
-				captureSession.AddInput(captureInput);
+							if (isCorrectPosition)
+							{
+								// Prefer multi-camera systems (Dual, Triple, DualWide) - these are the main cameras on modern iPhones
+								if (device.DeviceType == AVCaptureDeviceType.BuiltInDualCamera ||
+									device.DeviceType == AVCaptureDeviceType.BuiltInTripleCamera ||
+									device.DeviceType == AVCaptureDeviceType.BuiltInDualWideCamera)
+								{
+									selectedDevice = device;
+									break; // Multi-camera systems are ideal for barcode scanning
+								}
+								// Wide-angle is a good standard camera
+								else if (device.DeviceType == AVCaptureDeviceType.BuiltInWideAngleCamera && selectedDevice == null)
+								{
+									selectedDevice = device;
+								}
+								// Avoid ultra-wide and telephoto, but keep as last resort fallback
+								else if (fallbackDevice == null)
+								{
+									fallbackDevice = device;
+								}
+							}
+						}
+
+						// Use selected device, or fallback if nothing better was found
+						captureDevice = selectedDevice ?? fallbackDevice;
+
+						if (captureDevice == null)
+							captureDevice = AVCaptureDevice.GetDefaultDevice(AVMediaTypes.Video);
+					}
+
+					if (captureDevice is null)
+						return;
+
+					captureInput = new AVCaptureDeviceInput(captureDevice, out var err);
+
+					captureSession.AddInput(captureInput);
+					ApplySelectedResolution();
 
 #if IOS
-				// Enable multitasking camera access for iPadOS Windowed Apps mode
-				// MultitaskingCameraAccess API is only available on iOS 16+
-				if (OperatingSystem.IsIOSVersionAtLeast(16))
-				{
-					if (captureSession.MultitaskingCameraAccessSupported)
+					// Enable multitasking camera access for iPadOS Windowed Apps mode
+					// MultitaskingCameraAccess API is available on iPadOS 16+.
+					if (OperatingSystem.IsIOSVersionAtLeast(16) && !OperatingSystem.IsMacCatalyst())
 					{
-						captureSession.BeginConfiguration();
-						captureSession.MultitaskingCameraAccessEnabled = true;
-						captureSession.CommitConfiguration();
+#pragma warning disable CA1416
+						EnableMultitaskingCameraAccess();
+#pragma warning restore CA1416
 					}
+#endif
 				}
+				finally
+				{
+					captureSession.CommitConfiguration();
+				}
+
+				if (wasRunning || startIfStopped)
+					captureSession.StartRunning();
+			}
+		}
+
+		partial void ApplyCameraOptions()
+		{
+			if (captureSession != null && captureDevice != null)
+				UpdateCamera();
+		}
+
+#if IOS
+		[SupportedOSPlatform("ios16.0")]
+		[UnsupportedOSPlatform("maccatalyst")]
+		void EnableMultitaskingCameraAccess()
+		{
+			if (captureSession.MultitaskingCameraAccessSupported)
+			{
+				captureSession.MultitaskingCameraAccessEnabled = true;
+			}
+		}
 #endif
 
-				captureSession.StartRunning();
+		void ApplySelectedResolution()
+		{
+			var supportedPresets = Resolutions
+				.Where(resolution => captureDevice.SupportsAVCaptureSessionPreset(resolution.Key))
+				.ToList();
+
+			if (supportedPresets.Count == 0)
+				return;
+
+			var selectedResolution = SelectResolution(supportedPresets.Select(resolution => new CameraResolution((int)resolution.Value.Width, (int)resolution.Value.Height)).ToList());
+			var selectedPreset = supportedPresets
+				.OrderBy(resolution => Distance(resolution.Value, selectedResolution))
+				.First()
+				.Key;
+
+			if (captureSession.CanSetSessionPreset(selectedPreset))
+				captureSession.SessionPreset = selectedPreset;
+		}
+
+		CameraResolution SelectResolution(IReadOnlyList<CameraResolution> availableResolutions)
+		{
+			if (Options.CameraResolutionSelector == null)
+				return new CameraResolution(640, 480);
+
+			try
+			{
+				return Options.CameraResolutionSelector(availableResolutions) ?? new CameraResolution(640, 480);
 			}
+			catch (Exception ex)
+			{
+				System.Diagnostics.Debug.WriteLine($"Camera resolution selector failed: {ex.Message}");
+				return new CameraResolution(640, 480);
+			}
+		}
+
+		static double Distance(MSize availableResolution, CameraResolution selectedResolution)
+		{
+			var widthDifference = availableResolution.Width - selectedResolution.Width;
+			var heightDifference = availableResolution.Height - selectedResolution.Height;
+			return (widthDifference * widthDifference) + (heightDifference * heightDifference);
 		}
 
 		public Task<IReadOnlyList<CameraInfo>> GetAvailableCameras()

--- a/ZXing.Net.MAUI/AssemblyInfo.cs
+++ b/ZXing.Net.MAUI/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ZXing.Net.MAUI.Tests")]

--- a/ZXing.Net.MAUI/BarcodeScannerOptions.cs
+++ b/ZXing.Net.MAUI/BarcodeScannerOptions.cs
@@ -3,6 +3,14 @@ using System.Collections.Generic;
 
 namespace ZXing.Net.Maui
 {
+	/// <summary>
+	/// Selects the camera resolution used for scanner frame analysis.
+	/// </summary>
+	/// <remarks>
+	/// Higher resolutions provide more pixels but increase conversion and decode cost for every frame.
+	/// Prefer the lowest resolution that reliably decodes for your use case instead of always selecting
+	/// the largest available resolution.
+	/// </remarks>
 	public delegate CameraResolution CameraResolutionSelectorDelegate(IReadOnlyList<CameraResolution> availableResolutions);
 
 	public record BarcodeReaderOptions
@@ -45,6 +53,13 @@ namespace ZXing.Net.Maui
 			init => initialDelayBeforeAnalyzingFrames = value >= 0 ? value : throw new ArgumentOutOfRangeException(nameof(value), "Delay must be greater than or equal to zero.");
 		}
 
+		/// <summary>
+		/// Gets the delegate used to choose the camera resolution for scanner frame analysis.
+		/// </summary>
+		/// <remarks>
+		/// This controls the frame size passed to the barcode decoder, so selecting the largest
+		/// available resolution can reduce scan throughput significantly.
+		/// </remarks>
 		public CameraResolutionSelectorDelegate CameraResolutionSelector { get; init; }
 
 	}

--- a/ZXing.Net.MAUI/BarcodeScannerOptions.cs
+++ b/ZXing.Net.MAUI/BarcodeScannerOptions.cs
@@ -1,8 +1,16 @@
-﻿namespace ZXing.Net.Maui
-{
-	public record BarcodeReaderOptions
+﻿using System;
+using System.Collections.Generic;
 
+namespace ZXing.Net.Maui
+{
+	public delegate CameraResolution CameraResolutionSelectorDelegate(IReadOnlyList<CameraResolution> availableResolutions);
+
+	public record BarcodeReaderOptions
 	{
+		int delayBetweenAnalyzingFrames = 150;
+		int delayBetweenContinuousScans = 1000;
+		int initialDelayBeforeAnalyzingFrames = 300;
+
 		public bool AutoRotate { get; init; }
 
 		public bool TryHarder { get; init; }
@@ -19,5 +27,25 @@
 
 		public bool AssumeGS1 { get; init; }
 
-    }
+		public int DelayBetweenAnalyzingFrames
+		{
+			get => delayBetweenAnalyzingFrames;
+			init => delayBetweenAnalyzingFrames = value >= 0 ? value : throw new ArgumentOutOfRangeException(nameof(value), "Delay must be greater than or equal to zero.");
+		}
+
+		public int DelayBetweenContinuousScans
+		{
+			get => delayBetweenContinuousScans;
+			init => delayBetweenContinuousScans = value >= 0 ? value : throw new ArgumentOutOfRangeException(nameof(value), "Delay must be greater than or equal to zero.");
+		}
+
+		public int InitialDelayBeforeAnalyzingFrames
+		{
+			get => initialDelayBeforeAnalyzingFrames;
+			init => initialDelayBeforeAnalyzingFrames = value >= 0 ? value : throw new ArgumentOutOfRangeException(nameof(value), "Delay must be greater than or equal to zero.");
+		}
+
+		public CameraResolutionSelectorDelegate CameraResolutionSelector { get; init; }
+
+	}
 }

--- a/ZXing.Net.MAUI/CameraBarcodeReaderViewHandler.cs
+++ b/ZXing.Net.MAUI/CameraBarcodeReaderViewHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.Versioning;
+using System.Threading;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
@@ -42,16 +43,55 @@ namespace ZXing.Net.Maui
         volatile ICameraBarcodeReaderView? _virtualView;
         volatile bool _isDetecting;
         volatile bool _isConnected;
+        int detectionSession;
 
         Readers.IBarcodeReader? barcodeReader;
+        BarcodeReaderOptions options = new();
+        readonly object barcodeReaderSync = new();
+        readonly ScannerTimingGate scannerTimingGate = new();
 
-        protected Readers.IBarcodeReader? BarcodeReader
-            => barcodeReader ??= Services?.GetService<Readers.IBarcodeReader>();
+        Readers.IBarcodeReader? GetBarcodeReader()
+        {
+            lock (barcodeReaderSync)
+            {
+                if (barcodeReader == null)
+                    barcodeReader = CreateBarcodeReader(options);
+
+                return barcodeReader;
+            }
+        }
+
+        Readers.IBarcodeReader? CreateBarcodeReader(BarcodeReaderOptions options)
+        {
+            var reader = Services?.GetService<Readers.IBarcodeReader>();
+            if (reader != null)
+                reader.Options = options;
+
+            return reader;
+        }
+
+        BarcodeResult[]? Decode(Readers.PixelBufferHolder data)
+        {
+            var reader = GetBarcodeReader();
+            return reader?.Decode(data);
+        }
+
+        void UpdateReaderOptions(BarcodeReaderOptions options)
+        {
+            lock (barcodeReaderSync)
+            {
+                this.options = options;
+
+                if (barcodeReader != null)
+                    barcodeReader = CreateBarcodeReader(options);
+            }
+        }
 
         protected override NativePlatformCameraPreviewView CreatePlatformView()
         {
             if (cameraManager == null)
                 cameraManager = new(MauiContext, VirtualView?.CameraLocation ?? CameraLocation.Rear);
+            cameraManager.UpdateOptions(VirtualView?.Options);
             var v = cameraManager.CreateNativeView();
             return v;
         }
@@ -61,11 +101,22 @@ namespace ZXing.Net.Maui
             base.ConnectHandler(nativeView);
 
             _virtualView = VirtualView;
+            _isDetecting = _virtualView?.IsDetecting ?? false;
+            scannerTimingGate.Reset();
+            scannerTimingGate.UpdateOptions(_virtualView?.Options);
 
             if (cameraManager != null)
             {
+                cameraManager.UpdateOptions(_virtualView?.Options);
+
                 if (await CameraManager.CheckPermissions())
                 {
+                    if (_isDetecting)
+                    {
+                        Interlocked.Increment(ref detectionSession);
+                        scannerTimingGate.StartInitialDelay();
+                    }
+
                     cameraManager.Connect();
                     _isConnected = true;
                 }
@@ -87,6 +138,8 @@ namespace ZXing.Net.Maui
 
             _isConnected = false;
             _virtualView = null;
+            Interlocked.Increment(ref detectionSession);
+            scannerTimingGate.Reset();
 
             base.DisconnectHandler(nativeView);
         }
@@ -100,27 +153,62 @@ namespace ZXing.Net.Maui
 
             if (_isDetecting)
             {
-                var barcodes = BarcodeReader?.Decode(e.Data);
-
-                if (barcodes != null && barcodes.Length > 0)
+                var currentDetectionSession = Volatile.Read(ref detectionSession);
+                if (scannerTimingGate.ShouldAnalyze())
                 {
-                    _virtualView?.BarcodesDetected(new BarcodeDetectionEventArgs(barcodes));
+                    BarcodeResult[]? barcodes = null;
+                    var detected = false;
+                    try
+                    {
+                        barcodes = Decode(e.Data);
+                        detected = barcodes != null && barcodes.Length > 0;
+                    }
+                    finally
+                    {
+                        if (IsCurrentDetectionSession(currentDetectionSession))
+                            scannerTimingGate.NotifyAnalyzed(detected);
+                    }
+
+                    if (IsCurrentDetectionSession(currentDetectionSession) && barcodes is { Length: > 0 })
+                        _virtualView?.BarcodesDetected(new BarcodeDetectionEventArgs(barcodes));
                 }
             }
         }
 
         public static void MapOptions(CameraBarcodeReaderViewHandler handler, ICameraBarcodeReaderView cameraBarcodeReaderView)
         {
-            if (handler.BarcodeReader != null)
-            {
-                handler.BarcodeReader.Options = cameraBarcodeReaderView.Options;
-            }
+            var options = cameraBarcodeReaderView.Options ?? new BarcodeReaderOptions();
+            handler.UpdateReaderOptions(options);
+            handler.scannerTimingGate.UpdateOptions(options);
+            handler.cameraManager?.UpdateOptions(options);
         }
 
         public static void MapIsDetecting(CameraBarcodeReaderViewHandler handler, ICameraBarcodeReaderView cameraBarcodeReaderView)
         {
-            handler._isDetecting = cameraBarcodeReaderView.IsDetecting;
+            var isDetecting = cameraBarcodeReaderView.IsDetecting;
+            if (handler._isDetecting == isDetecting)
+                return;
+
+            if (isDetecting)
+            {
+                Interlocked.Increment(ref handler.detectionSession);
+                handler.scannerTimingGate.Reset();
+
+                if (handler._isConnected)
+                    handler.scannerTimingGate.StartInitialDelay();
+
+                handler._isDetecting = true;
+            }
+            else
+            {
+                handler._isDetecting = false;
+                Interlocked.Increment(ref handler.detectionSession);
+                handler.scannerTimingGate.Reset();
+            }
         }
+
+        bool IsCurrentDetectionSession(int session)
+            => _isDetecting && session == Volatile.Read(ref detectionSession);
 
         public static async void MapVisibility(CameraBarcodeReaderViewHandler handler, ICameraBarcodeReaderView cameraBarcodeReaderView)
         {

--- a/ZXing.Net.MAUI/CameraManager.cs
+++ b/ZXing.Net.MAUI/CameraManager.cs
@@ -15,6 +15,7 @@ namespace ZXing.Net.Maui
 		}
 
 		protected readonly IMauiContext Context;
+		BarcodeReaderOptions options = new();
 
 #pragma warning disable CS0067
 		public event EventHandler<CameraFrameBufferEventArgs> FrameReady;
@@ -22,6 +23,8 @@ namespace ZXing.Net.Maui
 
 		public CameraLocation CameraLocation { get; private set; }
 		public CameraInfo SelectedCamera { get; private set; }
+
+		protected BarcodeReaderOptions Options => options;
 
 		/// <summary>
 		/// Gets a value indicating whether barcode scanning is supported on this device.
@@ -48,7 +51,23 @@ namespace ZXing.Net.Maui
 			UpdateCamera();
 		}
 
+		public void UpdateOptions(BarcodeReaderOptions options)
+		{
+			var nextOptions = options ?? new BarcodeReaderOptions();
+			var shouldApplyCameraOptions = ShouldApplyCameraOptions(this.options, nextOptions);
+
+			this.options = nextOptions;
+
+			if (shouldApplyCameraOptions)
+				ApplyCameraOptions();
+		}
+
+		internal static bool ShouldApplyCameraOptions(BarcodeReaderOptions currentOptions, BarcodeReaderOptions nextOptions)
+			=> currentOptions?.CameraResolutionSelector != nextOptions?.CameraResolutionSelector;
+
 		public static async Task<bool> CheckPermissions()
 			=> (await Permissions.RequestAsync<Permissions.Camera>()) == PermissionStatus.Granted;
+
+		partial void ApplyCameraOptions();
 	}
 }

--- a/ZXing.Net.MAUI/CameraResolution.cs
+++ b/ZXing.Net.MAUI/CameraResolution.cs
@@ -1,0 +1,19 @@
+namespace ZXing.Net.Maui
+{
+	public class CameraResolution
+	{
+		public CameraResolution()
+		{
+		}
+
+		public CameraResolution(int width, int height)
+		{
+			Width = width;
+			Height = height;
+		}
+
+		public int Width { get; set; }
+
+		public int Height { get; set; }
+	}
+}

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -1,5 +1,6 @@
-﻿using System.Runtime.Versioning;
+﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -47,7 +48,7 @@ namespace ZXing.Net.Maui
         private ProcessCameraProvider _cameraProvider;
         private ICamera _camera;
 
-        private static readonly Android.Util.Size ScreenSize = new(640, 480);
+        private static readonly Android.Util.Size DefaultResolution = new(640, 480);
 
         public NativePlatformCameraPreviewView CreateNativeView()
         {
@@ -66,35 +67,7 @@ namespace ZXing.Net.Maui
                 // Used to bind the lifecycle of cameras to the lifecycle owner
                 _cameraProvider = (ProcessCameraProvider)cameraProviderFuture.Get();
 
-                _resolutionSelector?.Dispose();
-
-                _resolutionSelector = new ResolutionSelector
-                    .Builder()
-                    .SetResolutionStrategy(new ResolutionStrategy(ScreenSize, ResolutionStrategy.FallbackRuleClosestHigherThenLower))
-                    .Build();
-
-                // Preview
-                _cameraPreview?.Dispose();
-
-                _cameraPreview = new Preview
-                    .Builder()
-                    .SetResolutionSelector(_resolutionSelector)
-                    .Build();
-
-                _cameraPreview.SetSurfaceProvider(_cameraExecutor, _previewView.SurfaceProvider);
-
-                // Frame by frame analyze
-                _imageAnalyzer?.Dispose();
-
-                _imageAnalyzer = new ImageAnalysis
-                    .Builder()
-                    .SetOutputImageFormat(ImageAnalysis.OutputImageFormatRgba8888)
-                    .SetResolutionSelector(_resolutionSelector)
-                    .SetBackpressureStrategy(ImageAnalysis.StrategyKeepOnlyLatest)
-                    .Build();
-
-                _imageAnalyzer.SetAnalyzer(_cameraExecutor, new FrameAnalyzer((buffer, size) =>
-                    FrameReady?.Invoke(this, new CameraFrameBufferEventArgs(new Readers.PixelBufferHolder { Data = buffer, Size = size }))));
+                ConfigureUseCases();
 
                 UpdateCamera();
 
@@ -114,7 +87,7 @@ namespace ZXing.Net.Maui
                 // Unbind use cases before rebinding
                 _cameraProvider.UnbindAll();
 
-                CameraSelector? selectedCameraSelector = null;
+                CameraSelector selectedCameraSelector = null;
 
                 // If a specific camera is selected, use it
                 if (SelectedCamera is not null)
@@ -221,6 +194,98 @@ namespace ZXing.Net.Maui
         public void UpdateTorch(bool on)
         {
             _camera?.CameraControl?.EnableTorch(on);
+        }
+
+        partial void ApplyCameraOptions()
+        {
+            if (_cameraProvider == null)
+                return;
+
+            _cameraProvider.UnbindAll();
+            ConfigureUseCases();
+            UpdateCamera();
+        }
+
+        void ConfigureUseCases()
+        {
+            _resolutionSelector?.Dispose();
+            _resolutionSelector = CreateResolutionSelector();
+
+            _cameraPreview?.Dispose();
+            _cameraPreview = new Preview
+                .Builder()
+                .SetResolutionSelector(_resolutionSelector)
+                .Build();
+
+            _cameraPreview.SetSurfaceProvider(_cameraExecutor, _previewView.SurfaceProvider);
+
+            _imageAnalyzer?.Dispose();
+            _imageAnalyzer = new ImageAnalysis
+                .Builder()
+                .SetOutputImageFormat(ImageAnalysis.OutputImageFormatRgba8888)
+                .SetResolutionSelector(_resolutionSelector)
+                .SetBackpressureStrategy(ImageAnalysis.StrategyKeepOnlyLatest)
+                .Build();
+
+            _imageAnalyzer.SetAnalyzer(_cameraExecutor, new FrameAnalyzer((buffer, size) =>
+                FrameReady?.Invoke(this, new CameraFrameBufferEventArgs(new Readers.PixelBufferHolder { Data = buffer, Size = size }))));
+        }
+
+        ResolutionSelector CreateResolutionSelector()
+        {
+            var builder = new ResolutionSelector
+                .Builder()
+                .SetResolutionStrategy(new ResolutionStrategy(DefaultResolution, ResolutionStrategy.FallbackRuleClosestHigherThenLower));
+
+            if (Options.CameraResolutionSelector != null)
+                builder.SetResolutionFilter(new CameraResolutionFilter(Options.CameraResolutionSelector));
+
+            return builder.Build();
+        }
+
+        sealed class CameraResolutionFilter : Java.Lang.Object, IResolutionFilter
+        {
+            readonly CameraResolutionSelectorDelegate selector;
+
+            public CameraResolutionFilter(CameraResolutionSelectorDelegate selector)
+                => this.selector = selector;
+
+            public IList<Android.Util.Size> Filter(IList<Android.Util.Size> supportedSizes, int rotationDegrees)
+            {
+                if (supportedSizes == null || supportedSizes.Count == 0)
+                    return supportedSizes;
+
+                var availableResolutions = supportedSizes
+                    .Select(size => new CameraResolution(size.Width, size.Height))
+                    .ToList();
+
+                CameraResolution selectedResolution;
+                try
+                {
+                    selectedResolution = selector(availableResolutions);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Camera resolution selector failed: {ex.Message}");
+                    return supportedSizes;
+                }
+
+                if (selectedResolution == null)
+                    return supportedSizes;
+
+                var selectedSize = supportedSizes.FirstOrDefault(size =>
+                    size.Width == selectedResolution.Width && size.Height == selectedResolution.Height);
+
+                if (selectedSize == null)
+                {
+                    Debug.WriteLine($"Camera resolution selector returned unsupported resolution: {selectedResolution.Width}x{selectedResolution.Height}");
+                    return supportedSizes;
+                }
+
+                return supportedSizes
+                    .OrderByDescending(size => size.Width == selectedSize.Width && size.Height == selectedSize.Height)
+                    .ToList();
+            }
         }
 
         public void Focus(Point point)

--- a/ZXing.Net.MAUI/Platforms/Windows/CameraManager.windows.cs
+++ b/ZXing.Net.MAUI/Platforms/Windows/CameraManager.windows.cs
@@ -25,8 +25,8 @@
 // Note 3 - the camera sharing mode is currently set to MediaCaptureSharingMode.SharedReadOnly, so multiple views of
 //          the same camera can be successfully created; the drawback is that the preview resolution can't be changed
 //          and the low level camera stream flows at its native resolution and format.
-//          To always get frames at the preview resolution (currently, 640 x 480 or 480 x 640, according to horizontal
-//          or vertical native camera layout) and also to preserve the native aspect ratio, keep the line
+//          To always get frames at the selected preview resolution (640 x 480 by default, or the
+//          CameraResolutionSelector result when set) and also to preserve the native aspect ratio, keep the line
 //          "#define FORCE_FRAMES_AT_PREVIEW_RESOLUTION" uncommented; on the other hand, to get frames at the native
 //          stream resolution (1920 x 1080 or 640 x 480 or whatever it is), comment out that line.
 #define ENABLE_DEVICE_WATCHER
@@ -218,6 +218,12 @@ namespace ZXing.Net.Maui
 		public void Dispose() { }
 		#endregion
 
+		partial void ApplyCameraOptions()
+		{
+			if (_mediaCapture != null)
+				TryEnqueueUI(async () => await UpdateCameraAsync(forceReinitialize: true));
+		}
+
 		#region Task helpers
 		private void TryEnqueueUI(DispatcherQueueHandler callback)
 		{
@@ -271,7 +277,7 @@ namespace ZXing.Net.Maui
 		}
 
 		//sourceGroupId is sent by the DeviceWatcher.
-		private async Task UpdateCameraAsync(string sourceGroupId = null)
+		private async Task UpdateCameraAsync(string sourceGroupId = null, bool forceReinitialize = false)
 		{
 			await ExecuteLockedAsync(async () =>
 			{
@@ -281,7 +287,7 @@ namespace ZXing.Net.Maui
 					return;
 				}
 
-				await InitCameraUnlockedAsync(sourceGroupId);
+				await InitCameraUnlockedAsync(sourceGroupId, forceReinitialize);
 			});
 		}
 
@@ -293,7 +299,7 @@ namespace ZXing.Net.Maui
 
 		//Initialize or update the camera, according to sourceGroupId parameter and CameraLocation property.
 		//The sourceGroupId is only sent by the DeviceWatcher.
-		private async Task InitCameraUnlockedAsync(string sourceGroupId = null)
+		private async Task InitCameraUnlockedAsync(string sourceGroupId = null, bool forceReinitialize = false)
 		{
 			try
 			{
@@ -337,12 +343,19 @@ namespace ZXing.Net.Maui
 				{
 					if (_currentMediaFrameSourceInfoId.Equals(selectedMediaFrameSourceInfo.Id))
 					{
-						//The selected camera is the same as the previous one: do nothing and exit.
-						return;
-					}
+						if (!forceReinitialize)
+						{
+							//The selected camera is the same as the previous one: do nothing and exit.
+							return;
+						}
 
-					//Reinit the camera, by releasing the previous MediaCapture resources.
-					await UninitCameraUnlockedAsync();
+						await UninitCameraUnlockedAsync();
+					}
+					else
+					{
+						//Reinit the camera, by releasing the previous MediaCapture resources.
+						await UninitCameraUnlockedAsync();
+					}
 				}
 
 				//Initialize the new MediaCapture instance.
@@ -365,10 +378,11 @@ namespace ZXing.Net.Maui
 				//Select and configure the required MediaFrameSource.
 				//If sharingMode is "SharedReadOnly", MediaFrameSource can't be configured.
 				var selectedMediaFrameSource = _mediaCapture.FrameSources[selectedMediaFrameSourceInfo.Id];
+				var selectedFrameReaderResolution = SelectFrameReaderResolution(selectedMediaFrameSource);
 				if (settings.SharingMode == MediaCaptureSharingMode.ExclusiveControl)
 				{
 					var preferredFormat = selectedMediaFrameSource.SupportedFormats.FirstOrDefault(f =>
-									(f.VideoFormat.Width == PreviewWidth && f.VideoFormat.Height == PreviewHeight));
+									(f.VideoFormat.Width == (uint)selectedFrameReaderResolution.Width && f.VideoFormat.Height == (uint)selectedFrameReaderResolution.Height));
 					if (preferredFormat != null)
 					{
 						await selectedMediaFrameSource.SetFormatAsync(preferredFormat);
@@ -382,20 +396,20 @@ namespace ZXing.Net.Maui
 				//Create the FrameReader bound to 'selectedMediaFrameSource' and attach the FrameArrived event.
 				//Automatically rescale the output frame by passing 'bitmapSize' to 'CreateFrameReaderAsync'.
 #if FORCE_FRAMES_AT_PREVIEW_RESOLUTION
-				var bitmapSize = new BitmapSize(PreviewWidth, PreviewHeight);
+				var bitmapSize = new BitmapSize((uint)selectedFrameReaderResolution.Width, (uint)selectedFrameReaderResolution.Height);
 				var videoFormat = selectedMediaFrameSource?.CurrentFormat?.VideoFormat;
 				if ((videoFormat?.Width > 0) && (videoFormat?.Height > 0))
 				{
 					if (videoFormat.Width >= videoFormat.Height)
 					{
 						//Horizontal layout: preserve preview minimal dimension as height; preserve native aspect ratio.
-						bitmapSize.Height = uint.Min(PreviewWidth, PreviewHeight);
+						bitmapSize.Height = uint.Min((uint)selectedFrameReaderResolution.Width, (uint)selectedFrameReaderResolution.Height);
 						bitmapSize.Width = (bitmapSize.Height * videoFormat.Width) / videoFormat.Height;
 					}
 					else
 					{
 						//Vertical layout: preserve preview minimal dimension as width; preserve native aspect ratio.
-						bitmapSize.Width = uint.Min(PreviewWidth, PreviewHeight);
+						bitmapSize.Width = uint.Min((uint)selectedFrameReaderResolution.Width, (uint)selectedFrameReaderResolution.Height);
 						bitmapSize.Height = (bitmapSize.Width * videoFormat.Height) / videoFormat.Width;
 					}
 				}
@@ -538,6 +552,43 @@ namespace ZXing.Net.Maui
 			}
 
 			return null;
+		}
+
+		private CameraResolution SelectFrameReaderResolution(MediaFrameSource selectedMediaFrameSource)
+		{
+			var fallbackResolution = new CameraResolution((int)PreviewWidth, (int)PreviewHeight);
+			if (Options.CameraResolutionSelector == null)
+				return fallbackResolution;
+
+			var availableResolutions = selectedMediaFrameSource.SupportedFormats
+				.Select(format => new CameraResolution((int)format.VideoFormat.Width, (int)format.VideoFormat.Height))
+				.Where(resolution => resolution.Width > 0 && resolution.Height > 0)
+				.GroupBy(resolution => (resolution.Width, resolution.Height))
+				.Select(group => group.First())
+				.ToList();
+
+			if (availableResolutions.Count == 0)
+				return fallbackResolution;
+
+			CameraResolution selectedResolution;
+			try
+			{
+				selectedResolution = Options.CameraResolutionSelector(availableResolutions);
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine(ex);
+				return fallbackResolution;
+			}
+
+			if (selectedResolution == null)
+				return fallbackResolution;
+
+			return availableResolutions.Any(resolution =>
+				resolution.Width == selectedResolution.Width &&
+				resolution.Height == selectedResolution.Height)
+				? selectedResolution
+				: fallbackResolution;
 		}
 
 		//Returns the camera with the specified device ID.

--- a/ZXing.Net.MAUI/ScannerTimingGate.cs
+++ b/ZXing.Net.MAUI/ScannerTimingGate.cs
@@ -1,0 +1,110 @@
+using System;
+
+namespace ZXing.Net.Maui
+{
+	internal sealed class ScannerTimingGate
+	{
+		readonly object sync = new();
+		readonly Func<long> getTimestamp;
+
+		BarcodeReaderOptions options = new();
+		long initializedAt;
+		long lastAnalysisAt;
+		long lastDetectionAt;
+		bool initialDelayStarted;
+		bool analysisInProgress;
+		bool hasAnalyzed;
+		bool hasDetected;
+
+		public ScannerTimingGate(Func<long> getTimestamp = null)
+		{
+			this.getTimestamp = getTimestamp ?? (() => Environment.TickCount64);
+		}
+
+		public void Reset()
+		{
+			lock (sync)
+			{
+				initializedAt = 0;
+				lastAnalysisAt = 0;
+				lastDetectionAt = 0;
+				initialDelayStarted = false;
+				analysisInProgress = false;
+				hasAnalyzed = false;
+				hasDetected = false;
+			}
+		}
+
+		public void StartInitialDelay()
+		{
+			lock (sync)
+				StartInitialDelay(getTimestamp());
+		}
+
+		public void UpdateOptions(BarcodeReaderOptions options)
+		{
+			lock (sync)
+			{
+				var previousInitialDelay = this.options.InitialDelayBeforeAnalyzingFrames;
+				this.options = options ?? new BarcodeReaderOptions();
+
+				if (initialDelayStarted && previousInitialDelay != this.options.InitialDelayBeforeAnalyzingFrames)
+					initializedAt = getTimestamp();
+			}
+		}
+
+		public bool ShouldAnalyze()
+		{
+			lock (sync)
+			{
+				var now = getTimestamp();
+
+				if (!initialDelayStarted)
+					StartInitialDelay(now);
+
+				if (!HasElapsed(now, initializedAt, options.InitialDelayBeforeAnalyzingFrames))
+					return false;
+
+				if (analysisInProgress)
+					return false;
+
+				if (hasDetected && !HasElapsed(now, lastDetectionAt, options.DelayBetweenContinuousScans))
+					return false;
+
+				if (hasAnalyzed && !HasElapsed(now, lastAnalysisAt, options.DelayBetweenAnalyzingFrames))
+					return false;
+
+				analysisInProgress = true;
+				return true;
+			}
+		}
+
+		public void NotifyAnalyzed(bool detected = false)
+		{
+			lock (sync)
+			{
+				var now = getTimestamp();
+
+				lastAnalysisAt = now;
+				hasAnalyzed = true;
+
+				if (detected)
+				{
+					lastDetectionAt = now;
+					hasDetected = true;
+				}
+
+				analysisInProgress = false;
+			}
+		}
+
+		void StartInitialDelay(long now)
+		{
+			initializedAt = now;
+			initialDelayStarted = true;
+		}
+
+		static bool HasElapsed(long now, long since, int delay)
+			=> delay <= 0 || now - since >= delay;
+	}
+}


### PR DESCRIPTION
## Summary
- Reintroduces Xamarin-era scanner options: `DelayBetweenAnalyzingFrames`, `InitialDelayBeforeAnalyzingFrames`, `DelayBetweenContinuousScans`, and `CameraResolutionSelector`.
- Wires scanner timing through a thread-safe gate and applies camera resolution selection on Android, iOS/Mac Catalyst, and Windows.
- Updates the sample app and README, and adds unit coverage for option defaults, init-only API shape, timing behavior, cooldown behavior, and camera-option reapply decisions.

Refs #302

## Validation
- `dotnet test ZXing.Net.MAUI.Tests/ZXing.Net.MAUI.Tests.csproj --no-restore -v:minimal`
- `dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-ios --no-restore -v:minimal`
- `dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-android --no-restore -v:minimal`
- `dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-maccatalyst --no-restore -v:minimal`
- `dotnet build ZXing.Net.MAUI.Controls/ZXing.Net.MAUI.Controls.csproj -f net10.0 --no-restore -v:minimal`
- `dotnet build BigIslandBarcode/BigIslandBarcode.csproj -f net10.0-android --no-restore -v:minimal`