### PR TITLE
Fix Android scanner disposal race

### DIFF
--- a/ZXing.Net.MAUI/CameraBarcodeReaderViewHandler.cs
+++ b/ZXing.Net.MAUI/CameraBarcodeReaderViewHandler.cs
@@ -105,11 +105,18 @@ namespace ZXing.Net.Maui
             scannerTimingGate.Reset();
             scannerTimingGate.UpdateOptions(_virtualView?.Options);
 
-            if (cameraManager != null)
-            {
-                cameraManager.UpdateOptions(_virtualView?.Options);
+            var manager = cameraManager;
 
-                if (await CameraManager.CheckPermissions())
+            if (manager != null)
+            {
+                manager.UpdateOptions(_virtualView?.Options);
+
+                var hasPermission = await CameraManager.CheckPermissions();
+
+                if (_virtualView == null || cameraManager != manager)
+                    return;
+
+                if (hasPermission)
                 {
                     if (_isDetecting)
                     {
@@ -117,11 +124,11 @@ namespace ZXing.Net.Maui
                         scannerTimingGate.StartInitialDelay();
                     }
 
-                    cameraManager.Connect();
+                    manager.Connect();
                     _isConnected = true;
                 }
 
-                cameraManager.FrameReady += CameraManager_FrameReady;
+                manager.FrameReady += CameraManager_FrameReady;
             }
         }
 
@@ -223,11 +230,14 @@ namespace ZXing.Net.Maui
                     {
                         // View became visible and camera is connected - rebind camera
                         // This ensures the camera preview works even if the view started invisible
-                        if (handler.cameraManager != null)
+                        var manager = handler.cameraManager;
+
+                        if (manager != null)
                         {
                             if (await CameraManager.CheckPermissions())
                             {
-                                handler.cameraManager.UpdateCamera();
+                                if (handler._isConnected && handler.cameraManager == manager)
+                                    manager.UpdateCamera();
                             }
                         }
                     }

--- a/ZXing.Net.MAUI/CameraViewHandler.cs
+++ b/ZXing.Net.MAUI/CameraViewHandler.cs
@@ -51,15 +51,22 @@ namespace ZXing.Net.Maui
 
 			_virtualView = VirtualView;
 
-			if (cameraManager != null)
+			var manager = cameraManager;
+
+			if (manager != null)
 			{
-				if (await CameraManager.CheckPermissions())
+				var hasPermission = await CameraManager.CheckPermissions();
+
+				if (_virtualView == null || cameraManager != manager)
+					return;
+
+				if (hasPermission)
 				{
-					cameraManager.Connect();
+					manager.Connect();
 					_isConnected = true;
 				}
 
-				cameraManager.FrameReady += CameraManager_FrameReady;
+				manager.FrameReady += CameraManager_FrameReady;
 			}
 		}
 
@@ -76,6 +83,7 @@ namespace ZXing.Net.Maui
 
 				cameraManager.Disconnect();
 				cameraManager.Dispose();
+				cameraManager = null;
 			}
 
 			_isConnected = false;
@@ -85,7 +93,10 @@ namespace ZXing.Net.Maui
 		}
 
 		public void Dispose()
-			=> cameraManager?.Dispose();
+		{
+			cameraManager?.Dispose();
+			cameraManager = null;
+		}
 
 		public void Focus(Point point)
 			=> cameraManager?.Focus(point);
@@ -127,11 +138,14 @@ namespace ZXing.Net.Maui
 					{
 						// View became visible and camera is connected - rebind camera
 						// This ensures the camera preview works even if the view started invisible
-						if (handler.cameraManager != null)
+						var manager = handler.cameraManager;
+
+						if (manager != null)
 						{
 							if (await CameraManager.CheckPermissions())
 							{
-								handler.cameraManager.UpdateCamera();
+								if (handler._isConnected && handler.cameraManager == manager)
+									manager.UpdateCamera();
 							}
 						}
 					}

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -47,6 +47,8 @@ namespace ZXing.Net.Maui
         private CameraSelector _cameraSelector = null;
         private ProcessCameraProvider _cameraProvider;
         private ICamera _camera;
+        private bool _isConnected;
+        private bool _isDisposed;
 
         private static readonly Android.Util.Size DefaultResolution = new(640, 480);
 
@@ -60,14 +62,33 @@ namespace ZXing.Net.Maui
 
         public void Connect()
         {
+            if (_isDisposed)
+                return;
+
+            _isConnected = true;
+
             var cameraProviderFuture = ProcessCameraProvider.GetInstance(Context.Context);
 
             cameraProviderFuture.AddListener(new Java.Lang.Runnable(() =>
             {
-                // Used to bind the lifecycle of cameras to the lifecycle owner
-                _cameraProvider = (ProcessCameraProvider)cameraProviderFuture.Get();
+                if (!_isConnected || _isDisposed)
+                    return;
 
-                ConfigureUseCases();
+                var previewView = _previewView;
+                var cameraExecutor = _cameraExecutor;
+
+                if (previewView == null || cameraExecutor == null)
+                    return;
+
+                // Used to bind the lifecycle of cameras to the lifecycle owner
+                var cameraProvider = (ProcessCameraProvider)cameraProviderFuture.Get();
+
+                if (!_isConnected || _isDisposed)
+                    return;
+
+                _cameraProvider = cameraProvider;
+
+                ConfigureUseCases(previewView, cameraExecutor);
 
                 UpdateCamera();
 
@@ -76,16 +97,25 @@ namespace ZXing.Net.Maui
 
         public void Disconnect()
         {
+            _isConnected = false;
+
             _cameraProvider?.UnbindAll();
             _cameraExecutor?.Shutdown();
         }
 
         public void UpdateCamera()
         {
-            if (_cameraProvider != null)
+            if (!_isConnected || _isDisposed)
+                return;
+
+            var cameraProvider = _cameraProvider;
+            var cameraPreview = _cameraPreview;
+            var imageAnalyzer = _imageAnalyzer;
+
+            if (cameraProvider != null && cameraPreview != null && imageAnalyzer != null)
             {
                 // Unbind use cases before rebinding
-                _cameraProvider.UnbindAll();
+                cameraProvider.UnbindAll();
 
                 CameraSelector selectedCameraSelector = null;
 
@@ -98,7 +128,7 @@ namespace ZXing.Net.Maui
                     {
                         var targetFacing = parts[0] == "front" ? CameraSelector.LensFacingFront : CameraSelector.LensFacingBack;
                         
-                        var availableCameraInfos = _cameraProvider.AvailableCameraInfos;
+                        var availableCameraInfos = cameraProvider.AvailableCameraInfos;
                         var facingIndex = 0;
                         
                         foreach (var cameraInfo in availableCameraInfos)
@@ -120,9 +150,9 @@ namespace ZXing.Net.Maui
                     var cameraLocation = CameraLocation;
 
                     // Select back camera as a default, or front camera otherwise
-                    if (cameraLocation == CameraLocation.Rear && _cameraProvider.HasCamera(CameraSelector.DefaultBackCamera))
+                    if (cameraLocation == CameraLocation.Rear && cameraProvider.HasCamera(CameraSelector.DefaultBackCamera))
                         selectedCameraSelector = CameraSelector.DefaultBackCamera;
-                    else if (cameraLocation == CameraLocation.Front && _cameraProvider.HasCamera(CameraSelector.DefaultFrontCamera))
+                    else if (cameraLocation == CameraLocation.Front && cameraProvider.HasCamera(CameraSelector.DefaultFrontCamera))
                         selectedCameraSelector = CameraSelector.DefaultFrontCamera;
                     else
                         selectedCameraSelector = CameraSelector.DefaultBackCamera;
@@ -136,12 +166,12 @@ namespace ZXing.Net.Maui
                 // The Context here SHOULD be something that's a lifecycle owner
                 if (Context.Context is AndroidX.Lifecycle.ILifecycleOwner lifecycleOwner)
                 {
-                    _camera = _cameraProvider.BindToLifecycle(lifecycleOwner, _cameraSelector, _cameraPreview, _imageAnalyzer);
+                    _camera = cameraProvider.BindToLifecycle(lifecycleOwner, _cameraSelector, cameraPreview, imageAnalyzer);
                 }
                 else if (Microsoft.Maui.ApplicationModel.Platform.CurrentActivity is AndroidX.Lifecycle.ILifecycleOwner maLifecycleOwner)
                 {
                     // if not, this should be sufficient as a fallback
-                    _camera = _cameraProvider.BindToLifecycle(maLifecycleOwner, _cameraSelector, _cameraPreview, _imageAnalyzer);
+                    _camera = cameraProvider.BindToLifecycle(maLifecycleOwner, _cameraSelector, cameraPreview, imageAnalyzer);
                 }
             }
         }
@@ -198,15 +228,22 @@ namespace ZXing.Net.Maui
 
         partial void ApplyCameraOptions()
         {
-            if (_cameraProvider == null)
+            if (!_isConnected || _isDisposed)
                 return;
 
-            _cameraProvider.UnbindAll();
-            ConfigureUseCases();
+            var cameraProvider = _cameraProvider;
+            var previewView = _previewView;
+            var cameraExecutor = _cameraExecutor;
+
+            if (cameraProvider == null || previewView == null || cameraExecutor == null)
+                return;
+
+            cameraProvider.UnbindAll();
+            ConfigureUseCases(previewView, cameraExecutor);
             UpdateCamera();
         }
 
-        void ConfigureUseCases()
+        void ConfigureUseCases(PreviewView previewView, IExecutorService cameraExecutor)
         {
             _resolutionSelector?.Dispose();
             _resolutionSelector = CreateResolutionSelector();
@@ -217,7 +254,7 @@ namespace ZXing.Net.Maui
                 .SetResolutionSelector(_resolutionSelector)
                 .Build();
 
-            _cameraPreview.SetSurfaceProvider(_cameraExecutor, _previewView.SurfaceProvider);
+            _cameraPreview.SetSurfaceProvider(cameraExecutor, previewView.SurfaceProvider);
 
             _imageAnalyzer?.Dispose();
             _imageAnalyzer = new ImageAnalysis
@@ -227,7 +264,7 @@ namespace ZXing.Net.Maui
                 .SetBackpressureStrategy(ImageAnalysis.StrategyKeepOnlyLatest)
                 .Build();
 
-            _imageAnalyzer.SetAnalyzer(_cameraExecutor, new FrameAnalyzer((buffer, size) =>
+            _imageAnalyzer.SetAnalyzer(cameraExecutor, new FrameAnalyzer((buffer, size) =>
                 FrameReady?.Invoke(this, new CameraFrameBufferEventArgs(new Readers.PixelBufferHolder { Data = buffer, Size = size }))));
         }
 
@@ -300,6 +337,15 @@ namespace ZXing.Net.Maui
 
         public void Dispose()
         {
+            if (_isDisposed)
+                return;
+
+            _isDisposed = true;
+            _isConnected = false;
+
+            _cameraProvider?.UnbindAll();
+            _cameraExecutor?.Shutdown();
+
             _imageAnalyzer?.Dispose();
             _imageAnalyzer = null;
 


### PR DESCRIPTION
## Summary
- guard Android `ProcessCameraProvider` callbacks so they no-op after the scanner manager is disconnected or disposed
- prevent handler permission/visibility async continuations from reconnecting or updating a stale camera manager after navigation or popup dismissal
- clear the plain camera handler manager on disconnect/dispose to avoid stale disposed-manager reuse

Fixes #301.

This is also related to the Android camera release/navigation lifecycle reports in #145, #164, #118, and #65. It may also help with the late Android `BindToLifecycle` reports in #129 and #176, although those can have other lifecycle-owner causes.

If you are affected by any of these issues, please try the PR build artifacts once CI publishes them and let us know whether closing/navigating away from the scanner now releases the camera without crashes or late reinitialization.

## Validation
- `dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-android`
- `dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0 --no-restore`