### PR TITLE
Fix iOS disconnect crash when camera permission is denied

### DIFF
--- a/ZXing.Net.MAUI.Tests/CameraManagerTests.cs
+++ b/ZXing.Net.MAUI.Tests/CameraManagerTests.cs
@@ -42,4 +42,23 @@ public class CameraManagerTests
 		Assert.False(CameraManager.ShouldApplyCameraOptions(selectorOptions, sameSelectorOptions));
 		Assert.True(CameraManager.ShouldApplyCameraOptions(selectorOptions, otherSelectorOptions));
 	}
+
+	[Fact]
+	public void ContainsReferenceReturnsFalseWhenInstanceIsNull()
+	{
+		var items = new[] { new object() };
+
+		Assert.False(CameraManager.ContainsReference(items, null));
+	}
+
+	[Fact]
+	public void ContainsReferenceReturnsTrueOnlyForSameInstance()
+	{
+		var shared = new object();
+		var sameValueDifferentInstance = new object();
+		var items = new[] { new object(), shared };
+
+		Assert.True(CameraManager.ContainsReference(items, shared));
+		Assert.False(CameraManager.ContainsReference(items, sameValueDifferentInstance));
+	}
 }

--- a/ZXing.Net.MAUI/Apple/CameraManager.ios.maccatalyst.cs
+++ b/ZXing.Net.MAUI/Apple/CameraManager.ios.maccatalyst.cs
@@ -315,7 +315,10 @@ namespace ZXing.Net.Maui
 				if (captureSession.Running)
 					captureSession.StopRunning();
 
-				captureSession.RemoveOutput(videoDataOutput);
+				if (ContainsReference(captureSession.Outputs, videoDataOutput))
+				{
+					captureSession.RemoveOutput(videoDataOutput);
+				}
 
 				// Cleanup old input
 				if (captureInput != null && captureSession.Inputs.Length > 0 && captureSession.Inputs.Contains(captureInput))

--- a/ZXing.Net.MAUI/CameraManager.cs
+++ b/ZXing.Net.MAUI/CameraManager.cs
@@ -65,6 +65,21 @@ namespace ZXing.Net.Maui
 		internal static bool ShouldApplyCameraOptions(BarcodeReaderOptions currentOptions, BarcodeReaderOptions nextOptions)
 			=> currentOptions?.CameraResolutionSelector != nextOptions?.CameraResolutionSelector;
 
+		internal static bool ContainsReference<T>(IReadOnlyCollection<T> items, object instance)
+			where T : class
+		{
+			if (instance is null || items is null || items.Count == 0)
+				return false;
+
+			foreach (var item in items)
+			{
+				if (ReferenceEquals(item, instance))
+					return true;
+			}
+
+			return false;
+		}
+
 		public static async Task<bool> CheckPermissions()
 			=> (await Permissions.RequestAsync<Permissions.Camera>()) == PermissionStatus.Granted;
 


### PR DESCRIPTION
## Summary
- guard Apple CameraManager.Disconnect() so it only removes videoDataOutput when the output instance exists and is actually attached to the session
- keep teardown behavior unchanged for connected sessions while making disconnect safe for permission-denied or unconnected flows
- add targeted regression tests for the new reference-check helper used by disconnect cleanup

## Root cause
When camera permission is denied, Connect() is not called, so videoDataOutput is never initialized or attached. During handler teardown, Disconnect() still called captureSession.RemoveOutput(videoDataOutput), which passed null and crashed with ArgumentNullException.

## Validation
- dotnet test ZXing.Net.MAUI.Tests/ZXing.Net.MAUI.Tests.csproj --nologo
- dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-ios --no-restore --nologo
- dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-maccatalyst --no-restore --nologo
- focused code-path simulation covered by new tests verifying the disconnect guard returns false when the output reference is null or untracked and true only for the exact attached instance

Fixes #306