### PR TITLE
Propagate camera options to CameraManager

### DIFF
--- a/ZXing.Net.MAUI.Tests/CameraManagerTests.cs
+++ b/ZXing.Net.MAUI.Tests/CameraManagerTests.cs
@@ -5,15 +5,44 @@ namespace ZXing.Net.MAUI.Tests;
 public class CameraManagerTests
 {
 	[Fact]
-	public void ShouldApplyCameraOptionsIgnoresDelayOnlyChanges()
+	public void CameraManagerOptionsOnlyIncludesCameraRelevantBarcodeReaderOptions()
 	{
-		var currentOptions = new BarcodeReaderOptions();
-		var nextOptions = new BarcodeReaderOptions
+		CameraResolutionSelectorDelegate selector = availableResolutions => availableResolutions.FirstOrDefault();
+		var barcodeOptions = new BarcodeReaderOptions
 		{
+			AutoRotate = true,
+			TryHarder = true,
+			Multiple = true,
+			DelayBetweenAnalyzingFrames = 1,
+			DelayBetweenContinuousScans = 2,
+			InitialDelayBeforeAnalyzingFrames = 3,
+			CameraResolutionSelector = selector
+		};
+
+		var cameraOptions = CameraManagerOptions.FromBarcodeReaderOptions(barcodeOptions);
+
+		Assert.True(cameraOptions.AutoRotate);
+		Assert.Same(selector, cameraOptions.CameraResolutionSelector);
+	}
+
+	[Fact]
+	public void CameraManagerOptionsUsesDefaultsWhenBarcodeReaderOptionsAreNull()
+	{
+		Assert.Equal(default, CameraManagerOptions.FromBarcodeReaderOptions(null));
+	}
+
+	[Fact]
+	public void ShouldApplyCameraOptionsIgnoresDecoderAndTimingOnlyChanges()
+	{
+		var currentOptions = CameraManagerOptions.FromBarcodeReaderOptions(new BarcodeReaderOptions());
+		var nextOptions = CameraManagerOptions.FromBarcodeReaderOptions(new BarcodeReaderOptions
+		{
+			TryHarder = true,
+			Multiple = true,
 			DelayBetweenAnalyzingFrames = 1,
 			DelayBetweenContinuousScans = 2,
 			InitialDelayBeforeAnalyzingFrames = 3
-		};
+		});
 
 		Assert.False(CameraManager.ShouldApplyCameraOptions(currentOptions, nextOptions));
 	}
@@ -37,10 +66,18 @@ public class CameraManagerTests
 			CameraResolutionSelector = otherSelector
 		};
 
-		Assert.True(CameraManager.ShouldApplyCameraOptions(noSelectorOptions, selectorOptions));
-		Assert.True(CameraManager.ShouldApplyCameraOptions(selectorOptions, noSelectorOptions));
-		Assert.False(CameraManager.ShouldApplyCameraOptions(selectorOptions, sameSelectorOptions));
-		Assert.True(CameraManager.ShouldApplyCameraOptions(selectorOptions, otherSelectorOptions));
+		Assert.True(CameraManager.ShouldApplyCameraOptions(
+			CameraManagerOptions.FromBarcodeReaderOptions(noSelectorOptions),
+			CameraManagerOptions.FromBarcodeReaderOptions(selectorOptions)));
+		Assert.True(CameraManager.ShouldApplyCameraOptions(
+			CameraManagerOptions.FromBarcodeReaderOptions(selectorOptions),
+			CameraManagerOptions.FromBarcodeReaderOptions(noSelectorOptions)));
+		Assert.False(CameraManager.ShouldApplyCameraOptions(
+			CameraManagerOptions.FromBarcodeReaderOptions(selectorOptions),
+			CameraManagerOptions.FromBarcodeReaderOptions(sameSelectorOptions)));
+		Assert.True(CameraManager.ShouldApplyCameraOptions(
+			CameraManagerOptions.FromBarcodeReaderOptions(selectorOptions),
+			CameraManagerOptions.FromBarcodeReaderOptions(otherSelectorOptions)));
 	}
 
 	[Fact]

--- a/ZXing.Net.MAUI/Apple/CameraManager.ios.maccatalyst.cs
+++ b/ZXing.Net.MAUI/Apple/CameraManager.ios.maccatalyst.cs
@@ -234,6 +234,9 @@ namespace ZXing.Net.Maui
 				UpdateCamera();
 		}
 
+		private static partial bool ShouldApplyPlatformCameraOptions(CameraManagerOptions currentOptions, CameraManagerOptions nextOptions)
+			=> false;
+
 #if IOS
 		[SupportedOSPlatform("ios16.0")]
 		[UnsupportedOSPlatform("maccatalyst")]

--- a/ZXing.Net.MAUI/CameraBarcodeReaderViewHandler.cs
+++ b/ZXing.Net.MAUI/CameraBarcodeReaderViewHandler.cs
@@ -91,7 +91,7 @@ namespace ZXing.Net.Maui
         {
             if (cameraManager == null)
                 cameraManager = new(MauiContext, VirtualView?.CameraLocation ?? CameraLocation.Rear);
-            cameraManager.UpdateOptions(VirtualView?.Options);
+            cameraManager.UpdateOptions(CameraManagerOptions.FromBarcodeReaderOptions(VirtualView?.Options));
             var v = cameraManager.CreateNativeView();
             return v;
         }
@@ -109,7 +109,7 @@ namespace ZXing.Net.Maui
 
             if (manager != null)
             {
-                manager.UpdateOptions(_virtualView?.Options);
+                manager.UpdateOptions(CameraManagerOptions.FromBarcodeReaderOptions(_virtualView?.Options));
 
                 var hasPermission = await CameraManager.CheckPermissions();
 
@@ -187,7 +187,7 @@ namespace ZXing.Net.Maui
             var options = cameraBarcodeReaderView.Options ?? new BarcodeReaderOptions();
             handler.UpdateReaderOptions(options);
             handler.scannerTimingGate.UpdateOptions(options);
-            handler.cameraManager?.UpdateOptions(options);
+            handler.cameraManager?.UpdateOptions(CameraManagerOptions.FromBarcodeReaderOptions(options));
         }
 
         public static void MapIsDetecting(CameraBarcodeReaderViewHandler handler, ICameraBarcodeReaderView cameraBarcodeReaderView)

--- a/ZXing.Net.MAUI/CameraManager.cs
+++ b/ZXing.Net.MAUI/CameraManager.cs
@@ -15,7 +15,7 @@ namespace ZXing.Net.Maui
 		}
 
 		protected readonly IMauiContext Context;
-		BarcodeReaderOptions options = new();
+		CameraManagerOptions options;
 
 #pragma warning disable CS0067
 		public event EventHandler<CameraFrameBufferEventArgs> FrameReady;
@@ -24,7 +24,7 @@ namespace ZXing.Net.Maui
 		public CameraLocation CameraLocation { get; private set; }
 		public CameraInfo SelectedCamera { get; private set; }
 
-		protected BarcodeReaderOptions Options => options;
+		protected CameraManagerOptions Options => options;
 
 		/// <summary>
 		/// Gets a value indicating whether barcode scanning is supported on this device.
@@ -51,19 +51,19 @@ namespace ZXing.Net.Maui
 			UpdateCamera();
 		}
 
-		public void UpdateOptions(BarcodeReaderOptions options)
+		public void UpdateOptions(CameraManagerOptions options)
 		{
-			var nextOptions = options ?? new BarcodeReaderOptions();
-			var shouldApplyCameraOptions = ShouldApplyCameraOptions(this.options, nextOptions);
+			var shouldApplyCameraOptions = ShouldApplyCameraOptions(this.options, options);
 
-			this.options = nextOptions;
+			this.options = options;
 
 			if (shouldApplyCameraOptions)
 				ApplyCameraOptions();
 		}
 
-		internal static bool ShouldApplyCameraOptions(BarcodeReaderOptions currentOptions, BarcodeReaderOptions nextOptions)
-			=> currentOptions?.CameraResolutionSelector != nextOptions?.CameraResolutionSelector;
+		internal static bool ShouldApplyCameraOptions(CameraManagerOptions currentOptions, CameraManagerOptions nextOptions)
+			=> currentOptions.CameraResolutionSelector != nextOptions.CameraResolutionSelector
+				|| ShouldApplyPlatformCameraOptions(currentOptions, nextOptions);
 
 		internal static bool ContainsReference<T>(IReadOnlyCollection<T> items, object instance)
 			where T : class
@@ -84,5 +84,7 @@ namespace ZXing.Net.Maui
 			=> (await Permissions.RequestAsync<Permissions.Camera>()) == PermissionStatus.Granted;
 
 		partial void ApplyCameraOptions();
+
+		private static partial bool ShouldApplyPlatformCameraOptions(CameraManagerOptions currentOptions, CameraManagerOptions nextOptions);
 	}
 }

--- a/ZXing.Net.MAUI/CameraManagerOptions.cs
+++ b/ZXing.Net.MAUI/CameraManagerOptions.cs
@@ -1,0 +1,8 @@
+namespace ZXing.Net.Maui
+{
+	internal readonly record struct CameraManagerOptions(bool AutoRotate, CameraResolutionSelectorDelegate CameraResolutionSelector)
+	{
+		public static CameraManagerOptions FromBarcodeReaderOptions(BarcodeReaderOptions options)
+			=> options is null ? default : new CameraManagerOptions(options.AutoRotate, options.CameraResolutionSelector);
+	}
+}

--- a/ZXing.Net.MAUI/CameraManagerOptions.cs
+++ b/ZXing.Net.MAUI/CameraManagerOptions.cs
@@ -1,8 +1,10 @@
+#nullable enable
+
 namespace ZXing.Net.Maui
 {
-	internal readonly record struct CameraManagerOptions(bool AutoRotate, CameraResolutionSelectorDelegate CameraResolutionSelector)
+	internal readonly record struct CameraManagerOptions(bool AutoRotate, CameraResolutionSelectorDelegate? CameraResolutionSelector)
 	{
-		public static CameraManagerOptions FromBarcodeReaderOptions(BarcodeReaderOptions options)
+		public static CameraManagerOptions FromBarcodeReaderOptions(BarcodeReaderOptions? options)
 			=> options is null ? default : new CameraManagerOptions(options.AutoRotate, options.CameraResolutionSelector);
 	}
 }

--- a/ZXing.Net.MAUI/Net/CameraManager.net.cs
+++ b/ZXing.Net.MAUI/Net/CameraManager.net.cs
@@ -49,6 +49,9 @@ namespace ZXing.Net.Maui
             return Task.FromResult<IReadOnlyList<CameraInfo>>(new List<CameraInfo>());
         }
 
+        private static partial bool ShouldApplyPlatformCameraOptions(CameraManagerOptions currentOptions, CameraManagerOptions nextOptions)
+            => false;
+
         void LogUnsupported()
             => Debug.WriteLine("Camera preview is not supported on this platform.");
     }

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -243,6 +243,9 @@ namespace ZXing.Net.Maui
             UpdateCamera();
         }
 
+        private static partial bool ShouldApplyPlatformCameraOptions(CameraManagerOptions currentOptions, CameraManagerOptions nextOptions)
+            => currentOptions.AutoRotate != nextOptions.AutoRotate;
+
         void ConfigureUseCases(PreviewView previewView, IExecutorService cameraExecutor)
         {
             _resolutionSelector?.Dispose();
@@ -260,6 +263,7 @@ namespace ZXing.Net.Maui
             _imageAnalyzer = new ImageAnalysis
                 .Builder()
                 .SetOutputImageFormat(ImageAnalysis.OutputImageFormatRgba8888)
+                .SetOutputImageRotationEnabled(Options.AutoRotate)
                 .SetResolutionSelector(_resolutionSelector)
                 .SetBackpressureStrategy(ImageAnalysis.StrategyKeepOnlyLatest)
                 .Build();

--- a/ZXing.Net.MAUI/Platforms/Windows/CameraManager.windows.cs
+++ b/ZXing.Net.MAUI/Platforms/Windows/CameraManager.windows.cs
@@ -224,6 +224,9 @@ namespace ZXing.Net.Maui
 				TryEnqueueUI(async () => await UpdateCameraAsync(forceReinitialize: true));
 		}
 
+		private static partial bool ShouldApplyPlatformCameraOptions(CameraManagerOptions currentOptions, CameraManagerOptions nextOptions)
+			=> false;
+
 		#region Task helpers
 		private void TryEnqueueUI(DispatcherQueueHandler callback)
 		{


### PR DESCRIPTION
## Summary
- Add an internal `CameraManagerOptions` projection so `CameraManager` receives only camera-relevant settings from `BarcodeReaderOptions`
- Apply `AutoRotate` to Android CameraX `ImageAnalysis.Builder.SetOutputImageRotationEnabled(...)`
- Rebuild camera use cases when camera-relevant options change while ignoring decoder/timing-only option changes

Fixes #136

## Validation
- `dotnet test ZXing.Net.MAUI.Tests/ZXing.Net.MAUI.Tests.csproj -p:IsTestProject=true --verbosity minimal`
- `dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-android --verbosity minimal`
- `dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-ios --verbosity minimal`
- `dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-maccatalyst --verbosity minimal`
- `git diff --check`
