### PR TITLE
Add Android camera focus support

### DIFF
--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -98,13 +98,17 @@ namespace ZXing.Net.Maui
         {
             _isConnected = false;
 
-            _cameraProvider?.UnbindAll();
-            _camera = null;
-            _cameraExecutor?.Shutdown();
+            RunOnMainThread(DisconnectOnMainThread);
         }
 
         public void UpdateCamera()
         {
+            if (!IsMainThread)
+            {
+                RunOnMainThread(UpdateCamera);
+                return;
+            }
+
             if (!_isConnected || _isDisposed)
                 return;
 
@@ -230,6 +234,14 @@ namespace ZXing.Net.Maui
         }
 
         partial void ApplyCameraOptions()
+        {
+            if (!_isConnected || _isDisposed)
+                return;
+
+            RunOnMainThread(ApplyCameraOptionsOnMainThread);
+        }
+
+        void ApplyCameraOptionsOnMainThread()
         {
             if (!_isConnected || _isDisposed)
                 return;
@@ -364,9 +376,12 @@ namespace ZXing.Net.Maui
         bool CanFocus()
             => _isConnected && !_isDisposed && _camera != null && _previewView != null;
 
+        bool IsMainThread
+            => Android.OS.Looper.MyLooper() == Android.OS.Looper.MainLooper;
+
         void RunOnMainThread(Action action)
         {
-            if (Android.OS.Looper.MyLooper() == Android.OS.Looper.MainLooper)
+            if (IsMainThread)
                 action();
             else
                 ContextCompat.GetMainExecutor(Context.Context).Execute(new Java.Lang.Runnable(action));
@@ -378,6 +393,9 @@ namespace ZXing.Net.Maui
             var previewView = _previewView;
 
             if (!CanFocus() || camera == null || previewView == null)
+                return;
+
+            if (previewView.Width <= 0 || previewView.Height <= 0)
                 return;
 
             if (double.IsNaN(point.X) || double.IsNaN(point.Y) || double.IsInfinity(point.X) || double.IsInfinity(point.Y))
@@ -400,7 +418,22 @@ namespace ZXing.Net.Maui
             _isDisposed = true;
             _isConnected = false;
 
+            RunOnMainThread(DisposeOnMainThread);
+        }
+
+        void DisconnectOnMainThread()
+        {
             _cameraProvider?.UnbindAll();
+            _camera = null;
+            _cameraExecutor?.Shutdown();
+        }
+
+        void DisposeOnMainThread()
+        {
+            var camera = _camera;
+
+            _cameraProvider?.UnbindAll();
+            _camera = null;
             _cameraExecutor?.Shutdown();
 
             _imageAnalyzer?.Dispose();
@@ -424,8 +457,7 @@ namespace ZXing.Net.Maui
             _cameraExecutor?.Dispose();
             _cameraExecutor = null;
 
-            _camera?.Dispose();
-            _camera = null;
+            camera?.Dispose();
         }
     }
 }

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -355,7 +355,7 @@ namespace ZXing.Net.Maui
             if (!CanFocus())
                 return;
 
-            RunOnMainThread(() => FocusOnMainThread(point));
+            RunOnMainThread(() => FocusOnMainThread(point.X, point.Y, convertToPlatformPixels: true));
         }
 
         public void AutoFocus()
@@ -369,7 +369,7 @@ namespace ZXing.Net.Maui
                 if (!CanFocus() || previewView == null || previewView.Width <= 0 || previewView.Height <= 0)
                     return;
 
-                FocusOnMainThread(new Point(previewView.Width / 2d, previewView.Height / 2d));
+                FocusOnMainThread(previewView.Width / 2d, previewView.Height / 2d, convertToPlatformPixels: false);
             });
         }
 
@@ -387,7 +387,7 @@ namespace ZXing.Net.Maui
                 ContextCompat.GetMainExecutor(Context.Context).Execute(new Java.Lang.Runnable(action));
         }
 
-        void FocusOnMainThread(Point point)
+        void FocusOnMainThread(double x, double y, bool convertToPlatformPixels)
         {
             var camera = _camera;
             var previewView = _previewView;
@@ -398,16 +398,34 @@ namespace ZXing.Net.Maui
             if (previewView.Width <= 0 || previewView.Height <= 0)
                 return;
 
-            if (double.IsNaN(point.X) || double.IsNaN(point.Y) || double.IsInfinity(point.X) || double.IsInfinity(point.Y))
+            if (double.IsNaN(x) || double.IsNaN(y) || double.IsInfinity(x) || double.IsInfinity(y))
                 return;
 
-            var meteringPoint = previewView.MeteringPointFactory.CreatePoint((float)point.X, (float)point.Y);
+            if (convertToPlatformPixels)
+            {
+                x = ToPlatformPixels(x);
+                y = ToPlatformPixels(y);
+            }
+
+            if (x < 0 || y < 0 || x > previewView.Width || y > previewView.Height)
+                return;
+
+            var meteringPoint = previewView.MeteringPointFactory.CreatePoint((float)x, (float)y);
             var focusMeteringAction = new FocusMeteringAction.Builder(meteringPoint, FocusMeteringAction.FlagAf).Build();
 
             if (!camera.CameraInfo.IsFocusMeteringSupported(focusMeteringAction))
                 return;
 
             camera.CameraControl.StartFocusAndMetering(focusMeteringAction);
+        }
+
+        double ToPlatformPixels(double value)
+        {
+            var density = Context.Context.Resources?.DisplayMetrics?.Density ?? 1f;
+            if (float.IsNaN(density) || float.IsInfinity(density) || density <= 0f)
+                density = 1f;
+
+            return value * density;
         }
 
         public void Dispose()

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -119,8 +119,7 @@ namespace ZXing.Net.Maui
             if (cameraProvider != null && cameraPreview != null && imageAnalyzer != null)
             {
                 // Unbind use cases before rebinding
-                cameraProvider.UnbindAll();
-                _camera = null;
+                UnbindCamera(cameraProvider);
 
                 CameraSelector selectedCameraSelector = null;
 
@@ -253,8 +252,7 @@ namespace ZXing.Net.Maui
             if (cameraProvider == null || previewView == null || cameraExecutor == null)
                 return;
 
-            cameraProvider.UnbindAll();
-            _camera = null;
+            UnbindCamera(cameraProvider);
             ConfigureUseCases(previewView, cameraExecutor);
             UpdateCamera();
         }
@@ -441,17 +439,13 @@ namespace ZXing.Net.Maui
 
         void DisconnectOnMainThread()
         {
-            _cameraProvider?.UnbindAll();
-            _camera = null;
+            UnbindCamera(_cameraProvider);
             _cameraExecutor?.Shutdown();
         }
 
         void DisposeOnMainThread()
         {
-            var camera = _camera;
-
-            _cameraProvider?.UnbindAll();
-            _camera = null;
+            UnbindCamera(_cameraProvider);
             _cameraExecutor?.Shutdown();
 
             _imageAnalyzer?.Dispose();
@@ -474,7 +468,14 @@ namespace ZXing.Net.Maui
 
             _cameraExecutor?.Dispose();
             _cameraExecutor = null;
+        }
 
+        void UnbindCamera(ProcessCameraProvider cameraProvider)
+        {
+            var camera = _camera;
+
+            cameraProvider?.UnbindAll();
+            _camera = null;
             camera?.Dispose();
         }
     }

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -4,8 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
-using Android.Graphics;
-
 using AndroidX.Camera.Core;
 using AndroidX.Camera.Core.ResolutionSelector;
 using AndroidX.Camera.Lifecycle;
@@ -13,6 +11,7 @@ using AndroidX.Camera.View;
 using AndroidX.Core.Content;
 
 using Java.Util.Concurrent;
+using Microsoft.Maui.Graphics;
 
 namespace ZXing.Net.Maui
 {
@@ -100,6 +99,7 @@ namespace ZXing.Net.Maui
             _isConnected = false;
 
             _cameraProvider?.UnbindAll();
+            _camera = null;
             _cameraExecutor?.Shutdown();
         }
 
@@ -116,6 +116,7 @@ namespace ZXing.Net.Maui
             {
                 // Unbind use cases before rebinding
                 cameraProvider.UnbindAll();
+                _camera = null;
 
                 CameraSelector selectedCameraSelector = null;
 
@@ -241,6 +242,7 @@ namespace ZXing.Net.Maui
                 return;
 
             cameraProvider.UnbindAll();
+            _camera = null;
             ConfigureUseCases(previewView, cameraExecutor);
             UpdateCamera();
         }
@@ -338,12 +340,56 @@ namespace ZXing.Net.Maui
 
         public void Focus(Point point)
         {
+            if (!CanFocus())
+                return;
 
+            RunOnMainThread(() => FocusOnMainThread(point));
         }
 
         public void AutoFocus()
         {
+            if (!CanFocus())
+                return;
 
+            RunOnMainThread(() =>
+            {
+                var previewView = _previewView;
+                if (!CanFocus() || previewView == null || previewView.Width <= 0 || previewView.Height <= 0)
+                    return;
+
+                FocusOnMainThread(new Point(previewView.Width / 2d, previewView.Height / 2d));
+            });
+        }
+
+        bool CanFocus()
+            => _isConnected && !_isDisposed && _camera != null && _previewView != null;
+
+        void RunOnMainThread(Action action)
+        {
+            if (Android.OS.Looper.MyLooper() == Android.OS.Looper.MainLooper)
+                action();
+            else
+                ContextCompat.GetMainExecutor(Context.Context).Execute(new Java.Lang.Runnable(action));
+        }
+
+        void FocusOnMainThread(Point point)
+        {
+            var camera = _camera;
+            var previewView = _previewView;
+
+            if (!CanFocus() || camera == null || previewView == null)
+                return;
+
+            if (double.IsNaN(point.X) || double.IsNaN(point.Y) || double.IsInfinity(point.X) || double.IsInfinity(point.Y))
+                return;
+
+            var meteringPoint = previewView.MeteringPointFactory.CreatePoint((float)point.X, (float)point.Y);
+            var focusMeteringAction = new FocusMeteringAction.Builder(meteringPoint, FocusMeteringAction.FlagAf).Build();
+
+            if (!camera.CameraInfo.IsFocusMeteringSupported(focusMeteringAction))
+                return;
+
+            camera.CameraControl.StartFocusAndMetering(focusMeteringAction);
         }
 
         public void Dispose()


### PR DESCRIPTION
## Summary
- Implement Android CameraManager.Focus with PreviewView.MeteringPointFactory and CameraControl.StartFocusAndMetering.
- Implement Android AutoFocus as a one-shot center focus based on the current PreviewView dimensions.
- Guard focus calls when the camera is disconnected, disposed, unbound, or the preview is not measured; preserve existing Options.AutoRotate behavior.

## Validation
- dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-android -v:minimal
- dotnet test ZXing.Net.MAUI.Tests/ZXing.Net.MAUI.Tests.csproj -v:minimal

## Test coverage note
The existing unit test project targets the shared net10.0 surface and cannot exercise Android platform CameraX/PreviewView focus behavior directly, so this PR relies on the Android target build for CameraX binding validation.