### PR TITLE
Fix Android RGBA row stride handling

### DIFF
--- a/ZXing.Net.MAUI.Tests/RgbaFrameBufferTests.cs
+++ b/ZXing.Net.MAUI.Tests/RgbaFrameBufferTests.cs
@@ -1,0 +1,58 @@
+using ZXing.Net.Maui;
+
+namespace ZXing.Net.MAUI.Tests;
+
+public class RgbaFrameBufferTests
+{
+	[Fact]
+	public void CopyToContiguousRemovesPaddedRowBytes()
+	{
+		byte[] source =
+		[
+			1, 2, 3, 4, 5, 6, 7, 8, 101, 102, 103, 104,
+			9, 10, 11, 12, 13, 14, 15, 16, 105, 106, 107, 108
+		];
+		byte[] destination = new byte[16];
+
+		RgbaFrameBuffer.CopyToContiguous(source, destination, width: 2, height: 2, rowStride: 12, pixelStride: 4);
+
+		Assert.Equal(
+			[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+			destination);
+	}
+
+	[Fact]
+	public void CopyToContiguousHonorsPixelStride()
+	{
+		byte[] source =
+		[
+			1, 2, 3, 4, 101, 102, 103, 104, 5, 6, 7, 8, 105, 106, 107, 108,
+			9, 10, 11, 12, 109, 110, 111, 112, 13, 14, 15, 16, 113, 114, 115, 116
+		];
+		byte[] destination = new byte[16];
+
+		RgbaFrameBuffer.CopyToContiguous(source, destination, width: 2, height: 2, rowStride: 16, pixelStride: 8);
+
+		Assert.Equal(
+			[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+			destination);
+	}
+
+	[Fact]
+	public void IsContiguousRequiresTightRgbaRows()
+	{
+		Assert.True(RgbaFrameBuffer.IsContiguous(width: 2, height: 2, rowStride: 8, pixelStride: 4));
+		Assert.False(RgbaFrameBuffer.IsContiguous(width: 2, height: 2, rowStride: 12, pixelStride: 4));
+		Assert.False(RgbaFrameBuffer.IsContiguous(width: 2, height: 2, rowStride: 16, pixelStride: 8));
+	}
+
+	[Fact]
+	public void CopyToContiguousRejectsShortSourceBuffer()
+	{
+		byte[] source = [1, 2, 3, 4, 5, 6, 7];
+		byte[] destination = new byte[8];
+
+		Assert.Throws<ArgumentException>(() =>
+			RgbaFrameBuffer.CopyToContiguous(source, destination, width: 2, height: 1, rowStride: 8, pixelStride: 4));
+	}
+}

--- a/ZXing.Net.MAUI/Platforms/Android/FrameAnalyzer.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/FrameAnalyzer.cs
@@ -27,7 +27,13 @@ namespace ZXing.Net.Maui
         {
             try
             {
-                var buffer = image.GetPlanes()[0].Buffer;
+                var plane = image.GetPlanes()[0];
+                var buffer = CreateFrameBuffer(
+                    plane.Buffer,
+                    image.Width,
+                    image.Height,
+                    plane.RowStride,
+                    plane.PixelStride);
 
                 var s = new Size(image.Width, image.Height);
 
@@ -42,6 +48,36 @@ namespace ZXing.Net.Maui
             {
                 image.Close();
             }
+        }
+
+        static ByteBuffer CreateFrameBuffer(ByteBuffer sourceBuffer, int width, int height, int rowStride, int pixelStride)
+        {
+            var contiguousLength = RgbaFrameBuffer.GetContiguousLength(width, height);
+
+            if (RgbaFrameBuffer.IsContiguous(width, height, rowStride, pixelStride))
+                return PrepareBufferForRead(sourceBuffer, contiguousLength);
+
+            var requiredSourceLength = RgbaFrameBuffer.GetRequiredSourceLength(width, height, rowStride, pixelStride);
+            var source = PrepareBufferForRead(sourceBuffer, requiredSourceLength);
+            var sourceBytes = new byte[requiredSourceLength];
+            source.Get(sourceBytes, 0, sourceBytes.Length);
+
+            var contiguousBytes = new byte[contiguousLength];
+            RgbaFrameBuffer.CopyToContiguous(sourceBytes, contiguousBytes, width, height, rowStride, pixelStride);
+
+            return ByteBuffer.Wrap(contiguousBytes);
+        }
+
+        static ByteBuffer PrepareBufferForRead(ByteBuffer sourceBuffer, int length)
+        {
+            if (sourceBuffer.Limit() < length)
+                throw new ArgumentException("Source buffer limit is smaller than the RGBA frame layout requires.", nameof(sourceBuffer));
+
+            var buffer = sourceBuffer.Duplicate();
+            buffer.Position(0);
+            buffer.Limit(length);
+
+            return buffer;
         }
     }
 }

--- a/ZXing.Net.MAUI/RgbaFrameBuffer.cs
+++ b/ZXing.Net.MAUI/RgbaFrameBuffer.cs
@@ -1,0 +1,99 @@
+using System;
+
+namespace ZXing.Net.Maui
+{
+	internal static class RgbaFrameBuffer
+	{
+		public const int BytesPerPixel = 4;
+
+		public static int GetContiguousLength(int width, int height)
+		{
+			ValidateDimensions(width, height);
+
+			return checked(width * height * BytesPerPixel);
+		}
+
+		public static int GetRequiredSourceLength(int width, int height, int rowStride, int pixelStride)
+		{
+			ValidateLayout(width, height, rowStride, pixelStride);
+
+			if (width == 0 || height == 0)
+				return 0;
+
+			return checked(((height - 1) * rowStride) + ((width - 1) * pixelStride) + BytesPerPixel);
+		}
+
+		public static bool IsContiguous(int width, int height, int rowStride, int pixelStride)
+		{
+			ValidateLayout(width, height, rowStride, pixelStride);
+
+			return pixelStride == BytesPerPixel && rowStride == checked(width * BytesPerPixel);
+		}
+
+		public static void CopyToContiguous(
+			ReadOnlySpan<byte> source,
+			Span<byte> destination,
+			int width,
+			int height,
+			int rowStride,
+			int pixelStride)
+		{
+			var contiguousLength = GetContiguousLength(width, height);
+			if (destination.Length < contiguousLength)
+				throw new ArgumentException("Destination buffer is smaller than the contiguous RGBA frame size.", nameof(destination));
+
+			var requiredSourceLength = GetRequiredSourceLength(width, height, rowStride, pixelStride);
+			if (source.Length < requiredSourceLength)
+				throw new ArgumentException("Source buffer is smaller than the RGBA frame layout requires.", nameof(source));
+
+			if (contiguousLength == 0)
+				return;
+
+			for (var y = 0; y < height; y++)
+			{
+				var sourceRowOffset = y * rowStride;
+				var destinationRowOffset = y * width * BytesPerPixel;
+
+				if (pixelStride == BytesPerPixel)
+				{
+					source.Slice(sourceRowOffset, width * BytesPerPixel)
+						.CopyTo(destination.Slice(destinationRowOffset, width * BytesPerPixel));
+					continue;
+				}
+
+				for (var x = 0; x < width; x++)
+				{
+					source.Slice(sourceRowOffset + (x * pixelStride), BytesPerPixel)
+						.CopyTo(destination.Slice(destinationRowOffset + (x * BytesPerPixel), BytesPerPixel));
+				}
+			}
+		}
+
+		static void ValidateDimensions(int width, int height)
+		{
+			if (width < 0)
+				throw new ArgumentOutOfRangeException(nameof(width), "Width must not be negative.");
+
+			if (height < 0)
+				throw new ArgumentOutOfRangeException(nameof(height), "Height must not be negative.");
+		}
+
+		static void ValidateLayout(int width, int height, int rowStride, int pixelStride)
+		{
+			ValidateDimensions(width, height);
+
+			if (rowStride < 0)
+				throw new ArgumentOutOfRangeException(nameof(rowStride), "Row stride must not be negative.");
+
+			if (pixelStride < BytesPerPixel)
+				throw new ArgumentOutOfRangeException(nameof(pixelStride), "RGBA frames require at least four bytes per pixel.");
+
+			if (width == 0 || height == 0)
+				return;
+
+			var minimumRowStride = checked(((width - 1) * pixelStride) + BytesPerPixel);
+			if (rowStride < minimumRowStride)
+				throw new ArgumentException("Row stride is smaller than the RGBA pixels in a row require.", nameof(rowStride));
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Compact Android CameraX RGBA8888 frames when row stride includes padding or pixel stride exceeds RGBA byte width.
- Pass downstream buffers with position 0 and limit set to the contiguous width * height * 4 RGBA length.
- Add unit coverage for padded rows, pixel stride, contiguous detection, and short-source validation.

## Validation
- dotnet test ZXing.Net.MAUI.Tests/ZXing.Net.MAUI.Tests.csproj --verbosity minimal
- dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-android --no-restore --verbosity minimal
- dotnet build ZXing.Net.MAUI.Controls/ZXing.Net.MAUI.Controls.csproj -f net10.0-android --no-restore --verbosity minimal

## Remaining risk
- Not device-verified on hardware with padded CameraX RGBA rows; covered by extracted row-compaction tests.

## Linked issues
Fixes #124.