### PR TITLE
Add barcode image export API

### DIFF
--- a/BigIslandBarcode/App.xaml.cs
+++ b/BigIslandBarcode/App.xaml.cs
@@ -15,7 +15,7 @@ namespace BigIslandBarcode
 
 		protected override Window CreateWindow(IActivationState? activationState)
 		{
-			return new Window(new MainPage());
+			return new Window(new NavigationPage(new MainPage()));
 		}
 	}
 }

--- a/BigIslandBarcode/GeneratorPage.xaml
+++ b/BigIslandBarcode/GeneratorPage.xaml
@@ -1,0 +1,72 @@
+﻿<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="BigIslandBarcode.GeneratorPage"
+	Title="Barcode Generator">
+
+	<ScrollView>
+		<VerticalStackLayout Padding="20" Spacing="16">
+			<Label Text="Generate barcode image" FontSize="24" FontAttributes="Bold" />
+
+			<VerticalStackLayout Spacing="6">
+				<Label Text="Barcode value" />
+				<Entry x:Name="ValueEntry" Placeholder="Value to encode" />
+				<Label x:Name="FormatHelpLabel" FontSize="12" TextColor="Gray" LineBreakMode="WordWrap" />
+			</VerticalStackLayout>
+
+			<Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="12">
+				<VerticalStackLayout Spacing="6">
+					<Label Text="Barcode format" />
+					<Picker x:Name="FormatPicker" />
+				</VerticalStackLayout>
+
+				<VerticalStackLayout Grid.Column="1" Spacing="6">
+					<Label Text="Output image format" />
+					<Picker x:Name="ImageFormatPicker" />
+				</VerticalStackLayout>
+
+				<VerticalStackLayout Grid.Row="1" Spacing="6">
+					<Label Text="Output width (px)" />
+					<Entry x:Name="WidthEntry" Keyboard="Numeric" Text="512" />
+				</VerticalStackLayout>
+
+				<VerticalStackLayout Grid.Row="1" Grid.Column="1" Spacing="6">
+					<Label Text="Output height (px)" />
+					<Entry x:Name="HeightEntry" Keyboard="Numeric" Text="512" />
+				</VerticalStackLayout>
+
+				<VerticalStackLayout Grid.Row="2" Spacing="6">
+					<Label Text="Quiet zone margin" />
+					<Entry x:Name="MarginEntry" Keyboard="Numeric" Text="2" />
+				</VerticalStackLayout>
+
+				<VerticalStackLayout Grid.Row="2" Grid.Column="1" Spacing="6">
+					<Label Text="Character set hint (optional)" />
+					<Entry x:Name="CharacterSetEntry" Placeholder="e.g. UTF-8" />
+				</VerticalStackLayout>
+			</Grid>
+
+			<Grid ColumnDefinitions="*,*" ColumnSpacing="12">
+				<VerticalStackLayout Spacing="6">
+					<Label Text="Foreground color" />
+					<Picker x:Name="ForegroundColorPicker" />
+				</VerticalStackLayout>
+
+				<VerticalStackLayout Grid.Column="1" Spacing="6">
+					<Label Text="Background color" />
+					<Picker x:Name="BackgroundColorPicker" />
+				</VerticalStackLayout>
+			</Grid>
+
+			<Grid ColumnDefinitions="*,*" ColumnSpacing="12">
+				<Button Text="Generate Preview" Clicked="GeneratePreviewButton_Clicked" />
+				<Button Grid.Column="1" Text="Save Image" Clicked="SaveImageButton_Clicked" />
+			</Grid>
+
+			<Frame Padding="16" BackgroundColor="White" BorderColor="#DDDDDD" CornerRadius="8">
+				<Image x:Name="PreviewImage" HeightRequest="280" Aspect="AspectFit" />
+			</Frame>
+
+			<Label x:Name="StatusLabel" LineBreakMode="WordWrap" />
+		</VerticalStackLayout>
+	</ScrollView>
+</ContentPage>

--- a/BigIslandBarcode/GeneratorPage.xaml
+++ b/BigIslandBarcode/GeneratorPage.xaml
@@ -1,7 +1,17 @@
 ﻿<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	x:Class="BigIslandBarcode.GeneratorPage"
-	Title="Barcode Generator">
+	Title="Barcode Generator"
+	BackgroundColor="{AppThemeBinding Light=White, Dark=#101010}">
+
+	<ContentPage.Resources>
+		<ResourceDictionary>
+			<Style TargetType="Label">
+				<Setter Property="TextColor" Value="{AppThemeBinding Light=#1F1F1F, Dark=#F5F5F5}" />
+				<Setter Property="FontFamily" Value="OpenSansRegular" />
+			</Style>
+		</ResourceDictionary>
+	</ContentPage.Resources>
 
 	<ScrollView>
 		<VerticalStackLayout Padding="20" Spacing="16">
@@ -10,7 +20,7 @@
 			<VerticalStackLayout Spacing="6">
 				<Label Text="Barcode value" />
 				<Entry x:Name="ValueEntry" Placeholder="Value to encode" />
-				<Label x:Name="FormatHelpLabel" FontSize="12" TextColor="Gray" LineBreakMode="WordWrap" />
+				<Label x:Name="FormatHelpLabel" FontSize="12" TextColor="{AppThemeBinding Light=#6E6E6E, Dark=#BDBDBD}" LineBreakMode="WordWrap" />
 			</VerticalStackLayout>
 
 			<Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="12">
@@ -66,7 +76,7 @@
 				<Image x:Name="PreviewImage" HeightRequest="280" Aspect="AspectFit" />
 			</Frame>
 
-			<Label x:Name="StatusLabel" LineBreakMode="WordWrap" />
+			<Label x:Name="StatusLabel" TextColor="{AppThemeBinding Light=#6E6E6E, Dark=#BDBDBD}" LineBreakMode="WordWrap" />
 		</VerticalStackLayout>
 	</ScrollView>
 </ContentPage>

--- a/BigIslandBarcode/GeneratorPage.xaml
+++ b/BigIslandBarcode/GeneratorPage.xaml
@@ -50,7 +50,7 @@
 				</VerticalStackLayout>
 
 				<VerticalStackLayout Grid.Row="2" Grid.Column="1" Spacing="6">
-					<Label Text="Character set hint (optional)" />
+					<Label Text="Character set hint (optional)" MaxLines="1" LineBreakMode="TailTruncation" />
 					<Entry x:Name="CharacterSetEntry" Placeholder="e.g. UTF-8" />
 				</VerticalStackLayout>
 			</Grid>
@@ -68,9 +68,14 @@
 			</Grid>
 
 			<Grid ColumnDefinitions="*,*" ColumnSpacing="12">
-				<Button Text="Generate Preview" Clicked="GeneratePreviewButton_Clicked" />
-				<Button Grid.Column="1" Text="Save Image" Clicked="SaveImageButton_Clicked" />
+				<Button x:Name="GeneratePreviewButton" Text="Generate Preview" Clicked="GeneratePreviewButton_Clicked" />
+				<Button x:Name="SaveImageButton" Grid.Column="1" Text="Save Image" Clicked="SaveImageButton_Clicked" />
 			</Grid>
+
+			<HorizontalStackLayout x:Name="BusyLayout" Spacing="8" IsVisible="False">
+				<ActivityIndicator x:Name="BusyIndicator" IsRunning="False" />
+				<Label Text="Generating barcode image..." VerticalOptions="Center" TextColor="{AppThemeBinding Light=#6E6E6E, Dark=#BDBDBD}" />
+			</HorizontalStackLayout>
 
 			<Frame Padding="16" BackgroundColor="White" BorderColor="#DDDDDD" CornerRadius="8">
 				<Image x:Name="PreviewImage" HeightRequest="280" Aspect="AspectFit" />

--- a/BigIslandBarcode/GeneratorPage.xaml.cs
+++ b/BigIslandBarcode/GeneratorPage.xaml.cs
@@ -1,0 +1,358 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Storage;
+using ZXing.Net.Maui;
+
+namespace BigIslandBarcode
+{
+	public partial class GeneratorPage : ContentPage
+	{
+		readonly Dictionary<string, Color> colors = new()
+		{
+			["Black"] = Colors.Black,
+			["Dark Blue"] = Colors.DarkBlue,
+			[".NET Purple"] = Color.FromArgb("#512BD4"),
+			["Xamarin Blue"] = Color.FromArgb("#3199DC"),
+			["Red"] = Colors.Red,
+			["White"] = Colors.White,
+			["Transparent"] = Colors.Transparent
+		};
+
+		readonly List<BarcodeFormat> generatorFormats =
+		[
+			BarcodeFormat.Aztec,
+			BarcodeFormat.Codabar,
+			BarcodeFormat.Code39,
+			BarcodeFormat.Code93,
+			BarcodeFormat.Code128,
+			BarcodeFormat.DataMatrix,
+			BarcodeFormat.Ean8,
+			BarcodeFormat.Ean13,
+			BarcodeFormat.Itf,
+			BarcodeFormat.Msi,
+			BarcodeFormat.Pdf417,
+			BarcodeFormat.Plessey,
+			BarcodeFormat.QrCode,
+			BarcodeFormat.UpcA,
+			BarcodeFormat.UpcE
+		];
+
+		byte[] previewBytes;
+		bool generatedInitialPreview;
+		bool updatingValueText;
+
+		public GeneratorPage(string value = null, BarcodeFormat format = BarcodeFormat.QrCode)
+		{
+			InitializeComponent();
+
+			FormatPicker.ItemsSource = generatorFormats.Select(format => format.ToString()).ToList();
+			ImageFormatPicker.ItemsSource = Enum.GetValues<BarcodeImageFormat>().Select(format => format.ToString()).ToList();
+			ForegroundColorPicker.ItemsSource = colors.Keys.ToList();
+			BackgroundColorPicker.ItemsSource = colors.Keys.ToList();
+
+			ValueEntry.Text = string.IsNullOrEmpty(value) ? "I love .NET MAUI" : value;
+			FormatPicker.SelectedItem = generatorFormats.Contains(format)
+				? format.ToString()
+				: BarcodeFormat.QrCode.ToString();
+			ImageFormatPicker.SelectedItem = BarcodeImageFormat.Png.ToString();
+			ForegroundColorPicker.SelectedItem = ".NET Purple";
+			BackgroundColorPicker.SelectedItem = "White";
+
+			FormatPicker.SelectedIndexChanged += FormatPicker_SelectedIndexChanged;
+			ValueEntry.TextChanged += ValueEntry_TextChanged;
+			FormatPicker_SelectedIndexChanged(this, EventArgs.Empty);
+		}
+
+		protected override async void OnAppearing()
+		{
+			base.OnAppearing();
+
+			if (generatedInitialPreview)
+				return;
+
+			generatedInitialPreview = true;
+			await GeneratePreviewAsync();
+		}
+
+		async void GeneratePreviewButton_Clicked(object sender, EventArgs e)
+		{
+			await GeneratePreviewAsync();
+		}
+
+		async void SaveImageButton_Clicked(object sender, EventArgs e)
+		{
+			try
+			{
+				var imageOptions = GetImageOptions();
+				var extension = imageOptions.Format == BarcodeImageFormat.Jpeg ? "jpg" : "png";
+				var filePath = Path.Combine(FileSystem.AppDataDirectory, $"barcode_{DateTime.Now:yyyyMMddHHmmss}.{extension}");
+
+				await BarcodeGenerator.WriteToFileAsync(
+					GetBarcodeValue(),
+					filePath,
+					GetGeneratorOptions(),
+					imageOptions);
+
+				StatusLabel.Text = $"Saved to {filePath}";
+				await DisplayAlertAsync("Barcode Saved", filePath, "OK");
+			}
+			catch (Exception ex) when (ex is ArgumentException
+				or IOException
+				or UnauthorizedAccessException
+				or PlatformNotSupportedException
+				or InvalidOperationException)
+			{
+				await DisplayAlertAsync("Save Failed", ex.Message, "OK");
+			}
+		}
+
+		async Task GeneratePreviewAsync()
+		{
+			try
+			{
+				await using var stream = new MemoryStream();
+				await BarcodeGenerator.WriteToStreamAsync(
+					GetBarcodeValue(),
+					stream,
+					GetGeneratorOptions(),
+					GetImageOptions());
+
+				previewBytes = stream.ToArray();
+				PreviewImage.Source = ImageSource.FromStream(() => new MemoryStream(previewBytes));
+				StatusLabel.Text = $"Preview generated: {previewBytes.Length:N0} bytes";
+			}
+			catch (Exception ex) when (ex is ArgumentException
+				or PlatformNotSupportedException
+				or InvalidOperationException)
+			{
+				PreviewImage.Source = null;
+				StatusLabel.Text = ex.Message;
+			}
+		}
+
+		BarcodeGeneratorOptions GetGeneratorOptions()
+		{
+			var format = GetSelectedEnum<BarcodeFormat>(FormatPicker, nameof(BarcodeGeneratorOptions.Format));
+			var value = GetBarcodeValue();
+			ValidateValue(format, value);
+
+			return new()
+			{
+				Format = format,
+				Width = GetPositiveInt(WidthEntry, nameof(BarcodeGeneratorOptions.Width)),
+				Height = GetPositiveInt(HeightEntry, nameof(BarcodeGeneratorOptions.Height)),
+				Margin = GetNonNegativeInt(MarginEntry, nameof(BarcodeGeneratorOptions.Margin)),
+				ForegroundColor = colors[(string)ForegroundColorPicker.SelectedItem],
+				BackgroundColor = colors[(string)BackgroundColorPicker.SelectedItem],
+				CharacterSet = string.IsNullOrWhiteSpace(CharacterSetEntry.Text) ? null : CharacterSetEntry.Text.Trim()
+			};
+		}
+
+		BarcodeImageOptions GetImageOptions()
+			=> new()
+			{
+				Format = GetSelectedEnum<BarcodeImageFormat>(ImageFormatPicker, nameof(BarcodeImageOptions.Format))
+			};
+
+		string GetBarcodeValue()
+		{
+			if (string.IsNullOrWhiteSpace(ValueEntry.Text))
+				throw new ArgumentException("Value is required.", nameof(ValueEntry));
+
+			return ValueEntry.Text;
+		}
+
+		static TEnum GetSelectedEnum<TEnum>(Picker picker, string optionName) where TEnum : struct, Enum
+		{
+			if (picker.SelectedItem is not string selectedItem || !Enum.TryParse<TEnum>(selectedItem, out var value))
+				throw new ArgumentException($"{optionName} is required.", optionName);
+
+			return value;
+		}
+
+		static int GetPositiveInt(Entry entry, string optionName)
+		{
+			if (!int.TryParse(entry.Text, out var value) || value <= 0)
+				throw new ArgumentException($"{optionName} must be greater than zero.", optionName);
+
+			return value;
+		}
+
+		static int GetNonNegativeInt(Entry entry, string optionName)
+		{
+			if (!int.TryParse(entry.Text, out var value) || value < 0)
+				throw new ArgumentException($"{optionName} must be greater than or equal to zero.", optionName);
+
+			return value;
+		}
+
+		void FormatPicker_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			var format = GetSelectedEnum<BarcodeFormat>(FormatPicker, nameof(BarcodeGeneratorOptions.Format));
+			ApplySelectedFormatRestrictions(format);
+		}
+
+		void ValueEntry_TextChanged(object sender, TextChangedEventArgs e)
+		{
+			if (updatingValueText)
+				return;
+
+			var format = GetSelectedEnum<BarcodeFormat>(FormatPicker, nameof(BarcodeGeneratorOptions.Format));
+			var filteredValue = FilterValue(format, e.NewTextValue ?? string.Empty);
+
+			if (filteredValue == e.NewTextValue)
+				return;
+
+			updatingValueText = true;
+			ValueEntry.Text = filteredValue;
+			updatingValueText = false;
+		}
+
+		void ApplySelectedFormatRestrictions(BarcodeFormat format)
+		{
+			var rule = GetInputRule(format);
+			FormatHelpLabel.Text = rule.HelpText;
+			ValueEntry.Keyboard = rule.DigitsOnly ? Keyboard.Numeric : Keyboard.Text;
+			ValueEntry.MaxLength = rule.MaxLength ?? int.MaxValue;
+
+			var currentValue = ValueEntry.Text ?? string.Empty;
+			var normalizedValue = NormalizeValue(format, currentValue);
+
+			if (!IsValidValue(format, normalizedValue))
+				normalizedValue = rule.SampleValue;
+
+			if (normalizedValue == currentValue)
+				return;
+
+			updatingValueText = true;
+			ValueEntry.Text = normalizedValue;
+			updatingValueText = false;
+		}
+
+		static void ValidateValue(BarcodeFormat format, string value)
+		{
+			switch (format)
+			{
+				case BarcodeFormat.Codabar:
+					RequireAllowedCharacters(format, value, GetInputRule(format).AllowedCharacters);
+					break;
+				case BarcodeFormat.Code39:
+					RequireAllowedCharacters(format, value, GetInputRule(format).AllowedCharacters);
+					break;
+				case BarcodeFormat.Ean8:
+					RequireDigits(format, value, 7, 8);
+					break;
+				case BarcodeFormat.Ean13:
+					RequireDigits(format, value, 12, 13);
+					break;
+				case BarcodeFormat.Itf:
+					RequireDigits(format, value);
+					if (value.Length % 2 != 0)
+						throw new ArgumentException("ITF requires an even number of digits.");
+					break;
+				case BarcodeFormat.Msi:
+					RequireDigits(format, value);
+					break;
+				case BarcodeFormat.Plessey:
+					RequireAllowedCharacters(format, value, GetInputRule(format).AllowedCharacters);
+					break;
+				case BarcodeFormat.UpcA:
+					RequireDigits(format, value, 11, 12);
+					break;
+				case BarcodeFormat.UpcE:
+					RequireDigits(format, value, 7, 8);
+					break;
+			}
+		}
+
+		static void RequireDigits(BarcodeFormat format, string value, params int[] lengths)
+		{
+			if (!value.All(char.IsDigit))
+				throw new ArgumentException($"{format} requires digits only.");
+
+			if (lengths.Length > 0 && !lengths.Contains(value.Length))
+				throw new ArgumentException($"{format} requires {string.Join(" or ", lengths)} digits.");
+		}
+
+		static void RequireAllowedCharacters(BarcodeFormat format, string value, string allowedCharacters)
+		{
+			if (value.Any(character => !allowedCharacters.Contains(character)))
+				throw new ArgumentException($"{format} does not support this value. {GetInputRule(format).HelpText}");
+		}
+
+		static bool IsValidValue(BarcodeFormat format, string value)
+		{
+			if (string.IsNullOrWhiteSpace(value))
+				return false;
+
+			try
+			{
+				ValidateValue(format, value);
+				return true;
+			}
+			catch (ArgumentException)
+			{
+				return false;
+			}
+		}
+
+		static string NormalizeValue(BarcodeFormat format, string value)
+		{
+			var rule = GetInputRule(format);
+
+			if (rule.Uppercase)
+				value = value.ToUpperInvariant();
+
+			return value;
+		}
+
+		static string FilterValue(BarcodeFormat format, string value)
+		{
+			var rule = GetInputRule(format);
+			value = NormalizeValue(format, value);
+
+			if (rule.AllowedCharacters is not null)
+				value = new string(value.Where(character => rule.AllowedCharacters.Contains(character)).ToArray());
+			else if (rule.DigitsOnly)
+				value = new string(value.Where(char.IsDigit).ToArray());
+
+			return rule.MaxLength is { } maxLength && value.Length > maxLength
+				? value[..maxLength]
+				: value;
+		}
+
+		static FormatInputRule GetInputRule(BarcodeFormat format)
+			=> format switch
+			{
+				BarcodeFormat.Codabar => new("123456", "0123456789-$:/.+ABCDTN*E", true, null, "Codabar supports digits and - $ : / . +, with optional A-D start/stop characters. It cannot encode arbitrary text."),
+				BarcodeFormat.Code39 => new("I LOVE .NET MAUI", "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ -. $/+%", true, null, "Code 39 supports uppercase letters, digits, spaces, and - . $ / + %. Lowercase letters are converted to uppercase."),
+				BarcodeFormat.Ean8 => FormatInputRule.Digits("1234567", 8, "EAN-8 requires 7 or 8 digits."),
+				BarcodeFormat.Ean13 => FormatInputRule.Digits("5901234123457", 13, "EAN-13 requires 12 or 13 digits."),
+				BarcodeFormat.Itf => FormatInputRule.Digits("123456", null, "ITF requires an even number of digits."),
+				BarcodeFormat.Msi => FormatInputRule.Digits("123456", null, "MSI requires digits only."),
+				BarcodeFormat.Plessey => new("ABC123", "0123456789ABCDEF", true, null, "Plessey requires hexadecimal characters 0-9 or A-F."),
+				BarcodeFormat.UpcA => FormatInputRule.Digits("042100005264", 12, "UPC-A requires 11 or 12 digits."),
+				BarcodeFormat.UpcE => FormatInputRule.Digits("01234565", 8, "UPC-E requires 7 or 8 digits."),
+				_ => new("I love .NET MAUI", null, false, null, "This format can encode the default sample text.")
+			};
+
+		readonly record struct FormatInputRule(
+			string SampleValue,
+			string AllowedCharacters,
+			bool Uppercase,
+			int? MaxLength,
+			string HelpText)
+		{
+			public bool DigitsOnly => AllowedCharacters is not null && AllowedCharacters.All(char.IsDigit);
+
+			public static FormatInputRule Digits(string sampleValue, int? maxLength, string helpText)
+				=> new(sampleValue, "0123456789", false, maxLength, helpText);
+		}
+	}
+}

--- a/BigIslandBarcode/GeneratorPage.xaml.cs
+++ b/BigIslandBarcode/GeneratorPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -44,7 +45,9 @@ namespace BigIslandBarcode
 		];
 
 		byte[] previewBytes;
+		string previewCacheKey;
 		bool generatedInitialPreview;
+		bool isGenerating;
 		bool updatingValueText;
 
 		public GeneratorPage(string value = null, BarcodeFormat format = BarcodeFormat.QrCode)
@@ -89,15 +92,28 @@ namespace BigIslandBarcode
 		{
 			try
 			{
+				SetBusy(true);
 				var imageOptions = GetImageOptions();
+				var generatorOptions = GetGeneratorOptions();
+				var value = GetBarcodeValue();
 				var extension = imageOptions.Format == BarcodeImageFormat.Jpeg ? "jpg" : "png";
 				var filePath = Path.Combine(FileSystem.AppDataDirectory, $"barcode_{DateTime.Now:yyyyMMddHHmmss}.{extension}");
+				var cacheKey = CreateCacheKey(value, generatorOptions, imageOptions);
 
-				await BarcodeGenerator.WriteToFileAsync(
-					GetBarcodeValue(),
-					filePath,
-					GetGeneratorOptions(),
-					imageOptions);
+				await Task.Yield();
+
+				if (previewBytes is not null && previewCacheKey == cacheKey)
+				{
+					await File.WriteAllBytesAsync(filePath, previewBytes);
+				}
+				else
+				{
+					await BarcodeGenerator.WriteToFileAsync(
+						value,
+						filePath,
+						generatorOptions,
+						imageOptions);
+				}
 
 				StatusLabel.Text = $"Saved to {filePath}";
 				await DisplayAlertAsync("Barcode Saved", filePath, "OK");
@@ -110,22 +126,39 @@ namespace BigIslandBarcode
 			{
 				await DisplayAlertAsync("Save Failed", ex.Message, "OK");
 			}
+			finally
+			{
+				SetBusy(false);
+			}
 		}
 
 		async Task GeneratePreviewAsync()
 		{
+			if (isGenerating)
+				return;
+
 			try
 			{
+				SetBusy(true);
+				var value = GetBarcodeValue();
+				var generatorOptions = GetGeneratorOptions();
+				var imageOptions = GetImageOptions();
+				var cacheKey = CreateCacheKey(value, generatorOptions, imageOptions);
+				var stopwatch = Stopwatch.StartNew();
+
+				await Task.Yield();
+
 				await using var stream = new MemoryStream();
 				await BarcodeGenerator.WriteToStreamAsync(
-					GetBarcodeValue(),
+					value,
 					stream,
-					GetGeneratorOptions(),
-					GetImageOptions());
+					generatorOptions,
+					imageOptions);
 
 				previewBytes = stream.ToArray();
+				previewCacheKey = cacheKey;
 				PreviewImage.Source = ImageSource.FromStream(() => new MemoryStream(previewBytes));
-				StatusLabel.Text = $"Preview generated: {previewBytes.Length:N0} bytes";
+				StatusLabel.Text = $"Preview generated in {stopwatch.ElapsedMilliseconds:N0} ms: {previewBytes.Length:N0} bytes";
 			}
 			catch (Exception ex) when (ex is ArgumentException
 				or PlatformNotSupportedException
@@ -133,6 +166,10 @@ namespace BigIslandBarcode
 			{
 				PreviewImage.Source = null;
 				StatusLabel.Text = ex.Message;
+			}
+			finally
+			{
+				SetBusy(false);
 			}
 		}
 
@@ -159,6 +196,27 @@ namespace BigIslandBarcode
 			{
 				Format = GetSelectedEnum<BarcodeImageFormat>(ImageFormatPicker, nameof(BarcodeImageOptions.Format))
 			};
+
+		void SetBusy(bool busy)
+		{
+			isGenerating = busy;
+			BusyIndicator.IsRunning = busy;
+			BusyLayout.IsVisible = busy;
+			GeneratePreviewButton.IsEnabled = !busy;
+			SaveImageButton.IsEnabled = !busy;
+		}
+
+		static string CreateCacheKey(string value, BarcodeGeneratorOptions generatorOptions, BarcodeImageOptions imageOptions)
+			=> string.Join("|",
+				value,
+				generatorOptions.Format,
+				generatorOptions.Width,
+				generatorOptions.Height,
+				generatorOptions.Margin,
+				generatorOptions.ForegroundColor.ToArgbHex(),
+				generatorOptions.BackgroundColor.ToArgbHex(),
+				generatorOptions.CharacterSet ?? string.Empty,
+				imageOptions.Format);
 
 		string GetBarcodeValue()
 		{

--- a/BigIslandBarcode/GeneratorPage.xaml.cs
+++ b/BigIslandBarcode/GeneratorPage.xaml.cs
@@ -339,7 +339,7 @@ namespace BigIslandBarcode
 				BarcodeFormat.Plessey => new("ABC123", "0123456789ABCDEF", true, null, "Plessey requires hexadecimal characters 0-9 or A-F."),
 				BarcodeFormat.UpcA => FormatInputRule.Digits("042100005264", 12, "UPC-A requires 11 or 12 digits."),
 				BarcodeFormat.UpcE => FormatInputRule.Digits("01234565", 8, "UPC-E requires 7 or 8 digits."),
-				_ => new("I love .NET MAUI", null, false, null, "This format can encode the default sample text.")
+				_ => new("I love .NET MAUI", null, false, null, "This format can encode any text characters.")
 			};
 
 		readonly record struct FormatInputRule(

--- a/BigIslandBarcode/MainPage.xaml
+++ b/BigIslandBarcode/MainPage.xaml
@@ -29,7 +29,7 @@
 		</ResourceDictionary>
 	</ContentPage.Resources>
 
-	<Grid RowDefinitions="96,*,Auto">
+	<Grid RowDefinitions="128,*,Auto">
 
 		<zxing:CameraBarcodeReaderView
 			Grid.Row="0"
@@ -42,27 +42,53 @@
 			VerticalOptions="End"
 			HorizontalOptions="Fill"
 			BackgroundColor="#aa000000">
-			<Slider Minimum="0" Maximum="1" ValueChanged="ZoomFactorChanged" />
+			<Slider Minimum="0" Maximum="1" Margin="24,0,24,8" ValueChanged="ZoomFactorChanged" />
 		</Grid>
 
-		<Grid
+		<Border
 			Grid.Row="0"
-			BackgroundColor="#aa000000">
-			<Label
-				x:Name="ResultLabel"
-				Text="Point camera at a barcode"
-				HorizontalOptions="Center"
-				VerticalOptions="Center"
-				Margin="24,0"
-				LineBreakMode="TailTruncation"
-				TextColor="White" />
-		</Grid>
+			Margin="24,12"
+			Padding="14,10"
+			BackgroundColor="#CC000000"
+			Stroke="#55FFFFFF"
+			StrokeThickness="1"
+			HorizontalOptions="Fill"
+			VerticalOptions="Center">
+			<Border.StrokeShape>
+				<RoundRectangle CornerRadius="16" />
+			</Border.StrokeShape>
+			<Border.GestureRecognizers>
+				<TapGestureRecognizer Tapped="ResultPanel_Tapped" />
+			</Border.GestureRecognizers>
+			<VerticalStackLayout Spacing="2">
+				<Label
+					x:Name="ResultFormatLabel"
+					Text="Ready to scan"
+					FontSize="12"
+					FontAttributes="Bold"
+					TextColor="#BDBDBD" />
+				<Label
+					x:Name="ResultValueLabel"
+					Text="Point camera at a barcode"
+					FontSize="16"
+					FontAttributes="Bold"
+					MaxLines="2"
+					LineBreakMode="TailTruncation"
+					TextColor="White" />
+				<Label
+					x:Name="ResultHintLabel"
+					Text="Tap to view full value"
+					FontSize="11"
+					IsVisible="False"
+					TextColor="#BDBDBD" />
+			</VerticalStackLayout>
+		</Border>
 
 		<Grid
 			Grid.Row="2"
 			BackgroundColor="#99000000"
 			Padding="24,12,24,24"
-			ColumnDefinitions="*,*,*,*"
+			ColumnDefinitions="Auto,Auto,Auto,*,Auto"
 			ColumnSpacing="12">
 
 			<Button
@@ -81,18 +107,18 @@
 
 			<Button
 				Grid.Column="2"
+				Text="💡"
+				Style="{StaticResource ScannerButtonStyle}"
+				AutomationProperties.Name="Toggle torch"
+				Clicked="TorchButton_Clicked" />
+
+			<Button
+				Grid.Column="4"
 				Text="QR"
 				FontSize="18"
 				Style="{StaticResource PrimaryScannerButtonStyle}"
 				AutomationProperties.Name="Open barcode generator"
 				Clicked="GeneratorButton_Clicked" />
-
-			<Button
-				Grid.Column="3"
-				Text="💡"
-				Style="{StaticResource ScannerButtonStyle}"
-				AutomationProperties.Name="Toggle torch"
-				Clicked="TorchButton_Clicked" />
 		</Grid>
 
 	</Grid>

--- a/BigIslandBarcode/MainPage.xaml
+++ b/BigIslandBarcode/MainPage.xaml
@@ -30,7 +30,7 @@
 			Grid.Row="3"
 			BackgroundColor="#aa000000"
 			Padding="20"
-			ColumnDefinitions="Auto,Auto,*,Auto">
+			ColumnDefinitions="Auto,Auto,*,Auto,Auto">
 
 			<Button Text="🔄️" Grid.Column="0" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="SwitchCameraButton_Clicked" />
 
@@ -49,7 +49,9 @@
 				CharacterSet="UTF-8"
 				BarcodeMargin="1" />
 
-			<Button Text="💡" Grid.Column="3" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="TorchButton_Clicked" />
+			<Button Text="💾" Grid.Column="3" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="SaveBarcodeButton_Clicked" />
+
+			<Button Text="💡" Grid.Column="4" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="TorchButton_Clicked" />
 		</Grid>
 
 	</Grid>

--- a/BigIslandBarcode/MainPage.xaml
+++ b/BigIslandBarcode/MainPage.xaml
@@ -2,6 +2,7 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:zxing="clr-namespace:ZXing.Net.Maui.Controls;assembly=ZXing.Net.MAUI.Controls"
 	x:Class="BigIslandBarcode.MainPage"
+	NavigationPage.HasNavigationBar="False"
 	BackgroundColor="#000000">
 
 	<Grid RowDefinitions="1*,3*,1*">
@@ -30,28 +31,15 @@
 			Grid.Row="3"
 			BackgroundColor="#aa000000"
 			Padding="20"
-			ColumnDefinitions="Auto,Auto,*,Auto,Auto">
+			ColumnDefinitions="Auto,Auto,*,Auto">
 
 			<Button Text="🔄️" Grid.Column="0" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="SwitchCameraButton_Clicked" />
 
 			<Button Text="📷" Grid.Column="1" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="SelectCameraButton_Clicked" />
 
-			<zxing:BarcodeGeneratorView
-				x:Name="barcodeGenerator"
-				Grid.Column="2"
-				HorizontalOptions="Center"
-				VerticalOptions="Center"
-				HeightRequest="100"
-				WidthRequest="100"
-				ForegroundColor="DarkBlue"
-				Format="QrCode"
-				Value="测试中文 Test UTF-8"
-				CharacterSet="UTF-8"
-				BarcodeMargin="1" />
+			<Button Text="🏷️" Grid.Column="2" HorizontalOptions="Center" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="GeneratorButton_Clicked" />
 
-			<Button Text="💾" Grid.Column="3" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="SaveBarcodeButton_Clicked" />
-
-			<Button Text="💡" Grid.Column="4" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="TorchButton_Clicked" />
+			<Button Text="💡" Grid.Column="3" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="TorchButton_Clicked" />
 		</Grid>
 
 	</Grid>

--- a/BigIslandBarcode/MainPage.xaml
+++ b/BigIslandBarcode/MainPage.xaml
@@ -5,7 +5,31 @@
 	NavigationPage.HasNavigationBar="False"
 	BackgroundColor="#000000">
 
-	<Grid RowDefinitions="1*,3*,1*">
+	<ContentPage.Resources>
+		<ResourceDictionary>
+			<Style x:Key="ScannerButtonStyle" TargetType="Button">
+				<Setter Property="WidthRequest" Value="56" />
+				<Setter Property="HeightRequest" Value="56" />
+				<Setter Property="CornerRadius" Value="28" />
+				<Setter Property="Padding" Value="0" />
+				<Setter Property="BackgroundColor" Value="#CC000000" />
+				<Setter Property="BorderColor" Value="#55FFFFFF" />
+				<Setter Property="BorderWidth" Value="1" />
+				<Setter Property="TextColor" Value="White" />
+				<Setter Property="FontSize" Value="22" />
+				<Setter Property="HorizontalOptions" Value="Center" />
+				<Setter Property="VerticalOptions" Value="Center" />
+			</Style>
+
+			<Style x:Key="PrimaryScannerButtonStyle" TargetType="Button" BasedOn="{StaticResource ScannerButtonStyle}">
+				<Setter Property="BackgroundColor" Value="#512BD4" />
+				<Setter Property="BorderColor" Value="#8B6DFF" />
+				<Setter Property="FontAttributes" Value="Bold" />
+			</Style>
+		</ResourceDictionary>
+	</ContentPage.Resources>
+
+	<Grid RowDefinitions="96,*,Auto">
 
 		<zxing:CameraBarcodeReaderView
 			Grid.Row="0"
@@ -24,22 +48,51 @@
 		<Grid
 			Grid.Row="0"
 			BackgroundColor="#aa000000">
-			<Label x:Name="ResultLabel" Grid.Row="2" Text="Top text..." HorizontalOptions="Center" VerticalOptions="Center" TextColor="White" />
+			<Label
+				x:Name="ResultLabel"
+				Text="Point camera at a barcode"
+				HorizontalOptions="Center"
+				VerticalOptions="Center"
+				Margin="24,0"
+				LineBreakMode="TailTruncation"
+				TextColor="White" />
 		</Grid>
 
 		<Grid
-			Grid.Row="3"
-			BackgroundColor="#aa000000"
-			Padding="20"
-			ColumnDefinitions="Auto,Auto,*,Auto">
+			Grid.Row="2"
+			BackgroundColor="#99000000"
+			Padding="24,12,24,24"
+			ColumnDefinitions="*,*,*,*"
+			ColumnSpacing="12">
 
-			<Button Text="🔄️" Grid.Column="0" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="SwitchCameraButton_Clicked" />
+			<Button
+				Grid.Column="0"
+				Text="↻"
+				Style="{StaticResource ScannerButtonStyle}"
+				AutomationProperties.Name="Switch camera"
+				Clicked="SwitchCameraButton_Clicked" />
 
-			<Button Text="📷" Grid.Column="1" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="SelectCameraButton_Clicked" />
+			<Button
+				Grid.Column="1"
+				Text="📷"
+				Style="{StaticResource ScannerButtonStyle}"
+				AutomationProperties.Name="Select camera"
+				Clicked="SelectCameraButton_Clicked" />
 
-			<Button Text="🏷️" Grid.Column="2" HorizontalOptions="Center" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="GeneratorButton_Clicked" />
+			<Button
+				Grid.Column="2"
+				Text="QR"
+				FontSize="18"
+				Style="{StaticResource PrimaryScannerButtonStyle}"
+				AutomationProperties.Name="Open barcode generator"
+				Clicked="GeneratorButton_Clicked" />
 
-			<Button Text="💡" Grid.Column="3" BackgroundColor="#aa000000" CornerRadius="8" BorderColor="Black" Clicked="TorchButton_Clicked" />
+			<Button
+				Grid.Column="3"
+				Text="💡"
+				Style="{StaticResource ScannerButtonStyle}"
+				AutomationProperties.Name="Toggle torch"
+				Clicked="TorchButton_Clicked" />
 		</Grid>
 
 	</Grid>

--- a/BigIslandBarcode/MainPage.xaml.cs
+++ b/BigIslandBarcode/MainPage.xaml.cs
@@ -10,6 +10,7 @@ namespace BigIslandBarcode
 	{
 		string generatorValue = "I love .NET MAUI";
 		BarcodeFormat generatorFormat = BarcodeFormat.QrCode;
+		string lastScannedValue;
 
 		public MainPage()
 		{
@@ -65,7 +66,10 @@ namespace BigIslandBarcode
 				{
 					generatorFormat = first.Format;
 					generatorValue = first.Value;
-					ResultLabel.Text = $"Barcodes: {first.Format} -> {first.Value}";
+					lastScannedValue = first.Value;
+					ResultFormatLabel.Text = first.Format.ToString();
+					ResultValueLabel.Text = first.Value;
+					ResultHintLabel.IsVisible = true;
 				});
 			}
 		}
@@ -99,7 +103,9 @@ namespace BigIslandBarcode
 				if (selectedCamera != null)
 				{
 					barcodeView.SelectedCamera = selectedCamera;
-					ResultLabel.Text = $"Selected: {selectedCamera.Name}";
+					ResultFormatLabel.Text = "Camera";
+					ResultValueLabel.Text = $"Selected: {selectedCamera.Name}";
+					ResultHintLabel.IsVisible = false;
 				}
 			}
 		}
@@ -112,6 +118,14 @@ namespace BigIslandBarcode
 		async void GeneratorButton_Clicked(object sender, EventArgs e)
 		{
 			await Navigation.PushAsync(new GeneratorPage(generatorValue, generatorFormat));
+		}
+
+		async void ResultPanel_Tapped(object sender, TappedEventArgs e)
+		{
+			if (string.IsNullOrEmpty(lastScannedValue))
+				return;
+
+			await DisplayAlertAsync(generatorFormat.ToString(), lastScannedValue, "OK");
 		}
 
 		void ZoomFactorChanged(object sender, ValueChangedEventArgs e)

--- a/BigIslandBarcode/MainPage.xaml.cs
+++ b/BigIslandBarcode/MainPage.xaml.cs
@@ -38,6 +38,21 @@ namespace BigIslandBarcode
 				.First();
 		}
 
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			barcodeView.IsDetecting = true;
+		}
+
+		protected override void OnDisappearing()
+		{
+			barcodeView.IsDetecting = false;
+			barcodeView.IsTorchOn = false;
+
+			base.OnDisappearing();
+		}
+
 		protected void BarcodesDetected(object sender, BarcodeDetectionEventArgs e)
 		{
 			foreach (var barcode in e.Results)

--- a/BigIslandBarcode/MainPage.xaml.cs
+++ b/BigIslandBarcode/MainPage.xaml.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Storage;
 using ZXing.Net.Maui;
 using ZXing.Net.Maui.Controls;
 
@@ -95,6 +97,44 @@ namespace BigIslandBarcode
 		void TorchButton_Clicked(object sender, EventArgs e)
 		{
 			barcodeView.IsTorchOn = !barcodeView.IsTorchOn;
+		}
+
+		async void SaveBarcodeButton_Clicked(object sender, EventArgs e)
+		{
+			if (string.IsNullOrEmpty(barcodeGenerator.Value))
+			{
+				await DisplayAlertAsync("No Barcode", "Scan or enter a barcode value before saving.", "OK");
+				return;
+			}
+
+			try
+			{
+				var filePath = Path.Combine(FileSystem.AppDataDirectory, $"barcode_{DateTime.Now:yyyyMMddHHmmss}.png");
+				await BarcodeGenerator.WriteToFileAsync(
+					barcodeGenerator.Value,
+					filePath,
+					new BarcodeGeneratorOptions
+					{
+						Format = barcodeGenerator.Format,
+						Width = barcodeGenerator.WidthRequest > 0 ? (int)barcodeGenerator.WidthRequest : 300,
+						Height = barcodeGenerator.HeightRequest > 0 ? (int)barcodeGenerator.HeightRequest : 300,
+						ForegroundColor = barcodeGenerator.ForegroundColor,
+						BackgroundColor = barcodeGenerator.BackgroundColor,
+						Margin = barcodeGenerator.BarcodeMargin,
+						CharacterSet = barcodeGenerator.CharacterSet
+					});
+
+				ResultLabel.Text = "Barcode saved!";
+				await DisplayAlertAsync("Barcode Saved", filePath, "OK");
+			}
+			catch (Exception ex) when (ex is ArgumentException
+				or IOException
+				or UnauthorizedAccessException
+				or PlatformNotSupportedException
+				or InvalidOperationException)
+			{
+				await DisplayAlertAsync("Save Failed", ex.Message, "OK");
+			}
 		}
 
 		void ZoomFactorChanged(object sender, ValueChangedEventArgs e)

--- a/BigIslandBarcode/MainPage.xaml.cs
+++ b/BigIslandBarcode/MainPage.xaml.cs
@@ -1,17 +1,16 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Storage;
 using ZXing.Net.Maui;
-using ZXing.Net.Maui.Controls;
 
 namespace BigIslandBarcode
 {
 	public partial class MainPage : ContentPage
 	{
+		string generatorValue = "I love .NET MAUI";
+		BarcodeFormat generatorFormat = BarcodeFormat.QrCode;
+
 		public MainPage()
 		{
 			InitializeComponent();
@@ -49,13 +48,9 @@ namespace BigIslandBarcode
 			{
 				Dispatcher.Dispatch(() =>
 				{
-                    // Update BarcodeGeneratorView
-					barcodeGenerator.ClearValue(BarcodeGeneratorView.ValueProperty);
-					barcodeGenerator.Format = first.Format;
-					barcodeGenerator.Value = first.Value;
-                    
-                    // Update Label
-                    ResultLabel.Text = $"Barcodes: {first.Format} -> {first.Value}";
+					generatorFormat = first.Format;
+					generatorValue = first.Value;
+					ResultLabel.Text = $"Barcodes: {first.Format} -> {first.Value}";
 				});
 			}
 		}
@@ -99,42 +94,9 @@ namespace BigIslandBarcode
 			barcodeView.IsTorchOn = !barcodeView.IsTorchOn;
 		}
 
-		async void SaveBarcodeButton_Clicked(object sender, EventArgs e)
+		async void GeneratorButton_Clicked(object sender, EventArgs e)
 		{
-			if (string.IsNullOrEmpty(barcodeGenerator.Value))
-			{
-				await DisplayAlertAsync("No Barcode", "Scan or enter a barcode value before saving.", "OK");
-				return;
-			}
-
-			try
-			{
-				var filePath = Path.Combine(FileSystem.AppDataDirectory, $"barcode_{DateTime.Now:yyyyMMddHHmmss}.png");
-				await BarcodeGenerator.WriteToFileAsync(
-					barcodeGenerator.Value,
-					filePath,
-					new BarcodeGeneratorOptions
-					{
-						Format = barcodeGenerator.Format,
-						Width = barcodeGenerator.WidthRequest > 0 ? (int)barcodeGenerator.WidthRequest : 300,
-						Height = barcodeGenerator.HeightRequest > 0 ? (int)barcodeGenerator.HeightRequest : 300,
-						ForegroundColor = barcodeGenerator.ForegroundColor,
-						BackgroundColor = barcodeGenerator.BackgroundColor,
-						Margin = barcodeGenerator.BarcodeMargin,
-						CharacterSet = barcodeGenerator.CharacterSet
-					});
-
-				ResultLabel.Text = "Barcode saved!";
-				await DisplayAlertAsync("Barcode Saved", filePath, "OK");
-			}
-			catch (Exception ex) when (ex is ArgumentException
-				or IOException
-				or UnauthorizedAccessException
-				or PlatformNotSupportedException
-				or InvalidOperationException)
-			{
-				await DisplayAlertAsync("Save Failed", ex.Message, "OK");
-			}
+			await Navigation.PushAsync(new GeneratorPage(generatorValue, generatorFormat));
 		}
 
 		void ZoomFactorChanged(object sender, ValueChangedEventArgs e)

--- a/README.md
+++ b/README.md
@@ -178,6 +178,43 @@ protected void BarcodesDetected(object sender, BarcodeDetectionEventArgs e)
   Margin="3" />
 ```
 
+### Programmatic Barcode Image Export
+
+Use `BarcodeGenerator` when you need to create barcode images without a `BarcodeGeneratorView`, or when you want to write the generated image directly to a file or stream.
+
+```csharp
+var filePath = Path.Combine(FileSystem.AppDataDirectory, "barcode.png");
+
+await BarcodeGenerator.WriteToFileAsync(
+  "https://dotnet.microsoft.com",
+  filePath,
+  new BarcodeGeneratorOptions
+  {
+    Format = BarcodeFormat.QrCode,
+    Width = 512,
+    Height = 512,
+    Margin = 2,
+    ForegroundColor = Colors.DarkBlue,
+    BackgroundColor = Colors.White
+  });
+```
+
+You can also write to an existing stream and choose PNG or JPEG output:
+
+```csharp
+await using var stream = File.Create(filePath);
+
+await BarcodeGenerator.WriteToStreamAsync(
+  "https://dotnet.microsoft.com",
+  stream,
+  imageOptions: new BarcodeImageOptions
+  {
+    Format = BarcodeImageFormat.Png
+  });
+```
+
+`BarcodeGenerator.Generate(...)` returns the platform-native image type (`Bitmap` on Android, `UIImage` on iOS/MacCatalyst, and `WriteableBitmap` on Windows) if your app needs to display or process it directly. Image generation and writing are supported on Android, iOS, MacCatalyst, and Windows; the plain `net10.0` target throws `PlatformNotSupportedException` because it has no platform image encoder.
+
 ### Character Encoding
 
 If you need to encode international characters (e.g., Chinese, Japanese, Arabic, or other non-ASCII characters), you can specify a character encoding using the `CharacterSet` property:

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ await BarcodeGenerator.WriteToStreamAsync(
   });
 ```
 
-`BarcodeGenerator.Generate(...)` returns the platform-native image type (`Bitmap` on Android, `UIImage` on iOS/MacCatalyst, and `WriteableBitmap` on Windows) if your app needs to display or process it directly. Image generation and writing are supported on Android, iOS, MacCatalyst, and Windows; the plain `net10.0` target throws `PlatformNotSupportedException` because it has no platform image encoder.
+`BarcodeGenerator.Generate(...)` and `GenerateAsync(...)` return the platform-native image type (`Bitmap` on Android, `UIImage` on iOS/MacCatalyst, and `WriteableBitmap` on Windows) if your app needs to display or process it directly. Image generation and writing are supported on Android, iOS, MacCatalyst, and Windows; the plain `net10.0` target throws `PlatformNotSupportedException` because it has no platform image encoder.
 
 ### Character Encoding
 

--- a/ZXing.Net.MAUI.Tests/BarcodeGeneratorOptionsTests.cs
+++ b/ZXing.Net.MAUI.Tests/BarcodeGeneratorOptionsTests.cs
@@ -82,4 +82,14 @@ public class BarcodeGeneratorOptionsTests
 	{
 		Assert.Equal(ZXingBarcodeFormat.QR_CODE, BarcodeGenerator.GetZXingFormat(MauiBarcodeFormat.QrCode));
 	}
+
+	[Fact]
+	public async Task GenerateAsyncHonorsAlreadyCanceledToken()
+	{
+		using var cancellationTokenSource = new CancellationTokenSource();
+		await cancellationTokenSource.CancelAsync();
+
+		await Assert.ThrowsAsync<OperationCanceledException>(() =>
+			BarcodeGenerator.GenerateAsync("https://dotnet.microsoft.com", cancellationToken: cancellationTokenSource.Token));
+	}
 }

--- a/ZXing.Net.MAUI.Tests/BarcodeGeneratorOptionsTests.cs
+++ b/ZXing.Net.MAUI.Tests/BarcodeGeneratorOptionsTests.cs
@@ -1,0 +1,85 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Maui.Graphics;
+using ZXing.Net.Maui;
+using MauiBarcodeFormat = ZXing.Net.Maui.BarcodeFormat;
+using ZXingBarcodeFormat = ZXing.BarcodeFormat;
+
+namespace ZXing.Net.MAUI.Tests;
+
+public class BarcodeGeneratorOptionsTests
+{
+	[Fact]
+	public void DefaultsMatchGeneratorViewDefaults()
+	{
+		var options = new BarcodeGeneratorOptions();
+
+		Assert.Equal(MauiBarcodeFormat.QrCode, options.Format);
+		Assert.Equal(300, options.Width);
+		Assert.Equal(300, options.Height);
+		Assert.Equal(1, options.Margin);
+		Assert.Equal(Colors.Black.ToArgbHex(), options.ForegroundColor.ToArgbHex());
+		Assert.Equal(Colors.White.ToArgbHex(), options.BackgroundColor.ToArgbHex());
+		Assert.Null(options.CharacterSet);
+	}
+
+	[Fact]
+	public void InvalidGeneratorOptionsAreRejected()
+	{
+		Assert.Throws<ArgumentOutOfRangeException>(() => new BarcodeGeneratorOptions { Format = BarcodeFormats.TwoDimensional });
+		Assert.Throws<ArgumentOutOfRangeException>(() => new BarcodeGeneratorOptions { Width = 0 });
+		Assert.Throws<ArgumentOutOfRangeException>(() => new BarcodeGeneratorOptions { Height = 0 });
+		Assert.Throws<ArgumentOutOfRangeException>(() => new BarcodeGeneratorOptions { Margin = -1 });
+		Assert.Throws<ArgumentNullException>(() => new BarcodeGeneratorOptions { ForegroundColor = null });
+		Assert.Throws<ArgumentNullException>(() => new BarcodeGeneratorOptions { BackgroundColor = null });
+	}
+
+	[Theory]
+	[InlineData(nameof(BarcodeGeneratorOptions.Format))]
+	[InlineData(nameof(BarcodeGeneratorOptions.Width))]
+	[InlineData(nameof(BarcodeGeneratorOptions.Height))]
+	[InlineData(nameof(BarcodeGeneratorOptions.Margin))]
+	[InlineData(nameof(BarcodeGeneratorOptions.ForegroundColor))]
+	[InlineData(nameof(BarcodeGeneratorOptions.BackgroundColor))]
+	[InlineData(nameof(BarcodeGeneratorOptions.CharacterSet))]
+	public void GeneratorOptionPropertiesAreInitOnly(string propertyName)
+	{
+		var setMethod = typeof(BarcodeGeneratorOptions).GetProperty(propertyName)!.SetMethod;
+
+		Assert.NotNull(setMethod);
+		Assert.Contains(typeof(IsExternalInit), setMethod.ReturnParameter.GetRequiredCustomModifiers());
+	}
+
+	[Fact]
+	public void CreateEncodingOptionsMapsSharedOptions()
+	{
+		var options = new BarcodeGeneratorOptions
+		{
+			Format = MauiBarcodeFormat.Code128,
+			Width = 640,
+			Height = 320,
+			Margin = 4,
+			CharacterSet = "ISO-8859-1"
+		};
+
+		var encodingOptions = BarcodeGenerator.CreateEncodingOptions(options);
+
+		Assert.Equal(640, encodingOptions.Width);
+		Assert.Equal(320, encodingOptions.Height);
+		Assert.Equal(4, encodingOptions.Margin);
+		Assert.Equal("ISO-8859-1", encodingOptions.Hints[ZXing.EncodeHintType.CHARACTER_SET]);
+	}
+
+	[Fact]
+	public void CreateEncodingOptionsOmitsEmptyCharacterSet()
+	{
+		var encodingOptions = BarcodeGenerator.CreateEncodingOptions(new BarcodeGeneratorOptions());
+
+		Assert.False(encodingOptions.Hints.ContainsKey(ZXing.EncodeHintType.CHARACTER_SET));
+	}
+
+	[Fact]
+	public void GetZXingFormatMapsSingleFormat()
+	{
+		Assert.Equal(ZXingBarcodeFormat.QR_CODE, BarcodeGenerator.GetZXingFormat(MauiBarcodeFormat.QrCode));
+	}
+}

--- a/ZXing.Net.MAUI.Tests/BarcodeImageOptionsTests.cs
+++ b/ZXing.Net.MAUI.Tests/BarcodeImageOptionsTests.cs
@@ -1,0 +1,30 @@
+using System.Runtime.CompilerServices;
+using ZXing.Net.Maui;
+
+namespace ZXing.Net.MAUI.Tests;
+
+public class BarcodeImageOptionsTests
+{
+	[Fact]
+	public void DefaultsToPng()
+	{
+		var options = new BarcodeImageOptions();
+
+		Assert.Equal(BarcodeImageFormat.Png, options.Format);
+	}
+
+	[Fact]
+	public void InvalidImageFormatIsRejected()
+	{
+		Assert.Throws<ArgumentOutOfRangeException>(() => new BarcodeImageOptions { Format = (BarcodeImageFormat)42 });
+	}
+
+	[Fact]
+	public void ImageFormatPropertyIsInitOnly()
+	{
+		var setMethod = typeof(BarcodeImageOptions).GetProperty(nameof(BarcodeImageOptions.Format))!.SetMethod;
+
+		Assert.NotNull(setMethod);
+		Assert.Contains(typeof(IsExternalInit), setMethod.ReturnParameter.GetRequiredCustomModifiers());
+	}
+}

--- a/ZXing.Net.MAUI/Apple/BarcodeBitmapRenderer.ios.maccatalyst.cs
+++ b/ZXing.Net.MAUI/Apple/BarcodeBitmapRenderer.ios.maccatalyst.cs
@@ -32,12 +32,19 @@ namespace ZXing.Net.Maui
 			get => new UIColor(bitmapRenderer.BackgroundColor).AsColor();
 			set => bitmapRenderer.BackgroundColor = value.AsCGColor();
 		}
+
+		internal nfloat ImageScale
+		{
+			get => bitmapRenderer.ImageScale;
+			set => bitmapRenderer.ImageScale = value;
+		}
 	}
 
 	internal class BarcodeBitmapRenderer : IBarcodeRenderer<UIImage>
 	{
 		public CGColor ForegroundColor { get; set; } = new CGColor(0f, 0f, 0f);
 		public CGColor BackgroundColor { get; set; } = new CGColor(1.0f, 1.0f, 1.0f);
+		public nfloat ImageScale { get; set; } = UIScreen.MainScreen.Scale;
 
 		public UIImage Render(BitMatrix matrix, ZXing.BarcodeFormat format, string content)
 			=> Render(matrix, format, content, new EncodingOptions());
@@ -46,7 +53,7 @@ namespace ZXing.Net.Maui
 		{
 			var renderer = new UIGraphicsImageRenderer(new CGSize(matrix.Width, matrix.Height), new UIGraphicsImageRendererFormat {
 				Opaque = false,
-				Scale = UIScreen.MainScreen.Scale
+				Scale = ImageScale
 			});
 
 			var waiter = new ManualResetEvent(false);

--- a/ZXing.Net.MAUI/Apple/BarcodeBitmapRenderer.ios.maccatalyst.cs
+++ b/ZXing.Net.MAUI/Apple/BarcodeBitmapRenderer.ios.maccatalyst.cs
@@ -3,7 +3,6 @@ using ZXing.Rendering;
 using Microsoft.Maui.Graphics.Platform;
 using MauiColor = Microsoft.Maui.Graphics.Color;
 using ZXing.Common;
-using System.Threading;
 
 
 #if IOS || MACCATALYST
@@ -51,36 +50,37 @@ namespace ZXing.Net.Maui
 
 		public UIImage Render(BitMatrix matrix, ZXing.BarcodeFormat format, string content, EncodingOptions options)
 		{
-			var renderer = new UIGraphicsImageRenderer(new CGSize(matrix.Width, matrix.Height), new UIGraphicsImageRendererFormat {
+			var width = matrix.Width;
+			var height = matrix.Height;
+			var renderer = new UIGraphicsImageRenderer(new CGSize(width, height), new UIGraphicsImageRendererFormat {
 				Opaque = false,
 				Scale = ImageScale
 			});
 
-			var waiter = new ManualResetEvent(false);
-			UIImage image = null!;
-			
-			renderer.CreateImage(context =>
+			return renderer.CreateImage(context =>
 			{
-				for (var x = 0; x < matrix.Width; x++)
+				var cgContext = context.CGContext;
+				cgContext.SetFillColor(BackgroundColor);
+				cgContext.FillRect(new CGRect(0, 0, width, height));
+
+				cgContext.SetFillColor(ForegroundColor);
+				for (var y = 0; y < height; y++)
 				{
-					for (var y = 0; y < matrix.Height; y++)
+					var x = 0;
+					while (x < width)
 					{
-						context.CGContext.SetFillColor(matrix[x, y] ? ForegroundColor : BackgroundColor);
-						context.CGContext.FillRect(new CGRect(x, y, 1, 1));
+						while (x < width && !matrix[x, y])
+							x++;
+
+						var start = x;
+						while (x < width && matrix[x, y])
+							x++;
+
+						if (x > start)
+							cgContext.FillRect(new CGRect(start, y, x - start, 1));
 					}
 				}
-				
-				SetImage(context.CurrentImage);
 			});
-
-			waiter.WaitOne();
-			return image;
-			
-			void SetImage(UIImage img)
-			{
-				image = img;
-				waiter.Set();
-			}
 		}
 	}
 }

--- a/ZXing.Net.MAUI/Apple/BarcodeGenerator.ios.maccatalyst.cs
+++ b/ZXing.Net.MAUI/Apple/BarcodeGenerator.ios.maccatalyst.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Foundation;
+using UIKit;
+
+namespace ZXing.Net.Maui
+{
+	public static partial class BarcodeGenerator
+	{
+		private static partial async Task WriteImageToStreamAsync(
+			NativePlatformImage image,
+			Stream stream,
+			BarcodeImageOptions options,
+			CancellationToken cancellationToken)
+		{
+			ArgumentNullException.ThrowIfNull(image);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			using var data = options.Format switch
+			{
+				BarcodeImageFormat.Png => image.AsPNG(),
+				BarcodeImageFormat.Jpeg => image.AsJPEG(1f),
+				_ => throw new ArgumentOutOfRangeException(nameof(options), "Image format is not supported on this platform.")
+			};
+
+			if (data is null)
+				throw new InvalidOperationException("The barcode image could not be encoded.");
+
+			using var imageStream = data.AsStream();
+			await imageStream.CopyToAsync(stream, 81920, cancellationToken).ConfigureAwait(false);
+		}
+	}
+}

--- a/ZXing.Net.MAUI/BarcodeGenerator.cs
+++ b/ZXing.Net.MAUI/BarcodeGenerator.cs
@@ -1,0 +1,116 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ZXing;
+using ZXing.Common;
+
+namespace ZXing.Net.Maui
+{
+	public static partial class BarcodeGenerator
+	{
+		public static NativePlatformImage Generate(string value, BarcodeGeneratorOptions options = null)
+		{
+			ArgumentException.ThrowIfNullOrEmpty(value);
+
+#if ANDROID || IOS || MACCATALYST || WINDOWS
+			var generatorOptions = options ?? BarcodeGeneratorOptions.Default;
+			var writer = CreateWriter(generatorOptions);
+
+			return writer.Write(value);
+#else
+			throw new PlatformNotSupportedException("Barcode image generation requires Android, iOS, MacCatalyst, or Windows.");
+#endif
+		}
+
+		public static async Task WriteToStreamAsync(
+			string value,
+			Stream stream,
+			BarcodeGeneratorOptions options = null,
+			BarcodeImageOptions imageOptions = null,
+			CancellationToken cancellationToken = default)
+		{
+			ArgumentNullException.ThrowIfNull(stream);
+
+			if (!stream.CanWrite)
+				throw new ArgumentException("The stream must be writable.", nameof(stream));
+
+			cancellationToken.ThrowIfCancellationRequested();
+
+			var image = Generate(value, options);
+			await WriteImageToStreamAsync(image, stream, imageOptions ?? BarcodeImageOptions.Default, cancellationToken)
+				.ConfigureAwait(false);
+		}
+
+		public static async Task WriteToFileAsync(
+			string value,
+			string filePath,
+			BarcodeGeneratorOptions options = null,
+			BarcodeImageOptions imageOptions = null,
+			CancellationToken cancellationToken = default)
+		{
+			ArgumentException.ThrowIfNullOrEmpty(filePath);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			var image = Generate(value, options);
+			var directory = Path.GetDirectoryName(filePath);
+
+			if (!string.IsNullOrEmpty(directory))
+				Directory.CreateDirectory(directory);
+
+			await using var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, 81920, true);
+			await WriteImageToStreamAsync(image, stream, imageOptions ?? BarcodeImageOptions.Default, cancellationToken)
+				.ConfigureAwait(false);
+		}
+
+		internal static BarcodeWriter CreateWriter(BarcodeGeneratorOptions options)
+		{
+			var writer = new BarcodeWriter
+			{
+				Format = GetZXingFormat(options.Format),
+				ForegroundColor = options.ForegroundColor,
+				BackgroundColor = options.BackgroundColor
+			};
+
+#if IOS || MACCATALYST
+			writer.ImageScale = 1f;
+#endif
+
+			ApplyEncodingOptions(writer.Options, options);
+
+			return writer;
+		}
+
+		internal static EncodingOptions CreateEncodingOptions(BarcodeGeneratorOptions options)
+		{
+			var encodingOptions = new EncodingOptions();
+			ApplyEncodingOptions(encodingOptions, options);
+			return encodingOptions;
+		}
+
+		internal static ZXing.BarcodeFormat GetZXingFormat(BarcodeFormat format)
+		{
+			if (!Enum.IsDefined(format))
+				throw new ArgumentException("Barcode generation requires a single supported barcode format.", nameof(format));
+
+			return (ZXing.BarcodeFormat)format;
+		}
+
+		static void ApplyEncodingOptions(EncodingOptions encodingOptions, BarcodeGeneratorOptions options)
+		{
+			encodingOptions.Width = options.Width;
+			encodingOptions.Height = options.Height;
+			encodingOptions.Margin = options.Margin;
+			encodingOptions.Hints.Remove(EncodeHintType.CHARACTER_SET);
+
+			if (!string.IsNullOrEmpty(options.CharacterSet))
+				encodingOptions.Hints[EncodeHintType.CHARACTER_SET] = options.CharacterSet;
+		}
+
+		private static partial Task WriteImageToStreamAsync(
+			NativePlatformImage image,
+			Stream stream,
+			BarcodeImageOptions options,
+			CancellationToken cancellationToken);
+	}
+}

--- a/ZXing.Net.MAUI/BarcodeGenerator.cs
+++ b/ZXing.Net.MAUI/BarcodeGenerator.cs
@@ -23,6 +23,16 @@ namespace ZXing.Net.Maui
 #endif
 		}
 
+		public static Task<NativePlatformImage> GenerateAsync(
+			string value,
+			BarcodeGeneratorOptions options = null,
+			CancellationToken cancellationToken = default)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+
+			return Task.FromResult(Generate(value, options));
+		}
+
 		public static async Task WriteToStreamAsync(
 			string value,
 			Stream stream,

--- a/ZXing.Net.MAUI/BarcodeGeneratorOptions.cs
+++ b/ZXing.Net.MAUI/BarcodeGeneratorOptions.cs
@@ -1,0 +1,67 @@
+using System;
+using Microsoft.Maui.Graphics;
+
+namespace ZXing.Net.Maui
+{
+	public record BarcodeGeneratorOptions
+	{
+		int width = 300;
+		int height = 300;
+		int margin = 1;
+		BarcodeFormat format = BarcodeFormat.QrCode;
+		Color foregroundColor = Colors.Black;
+		Color backgroundColor = Colors.White;
+
+		public static BarcodeGeneratorOptions Default { get; } = new();
+
+		public BarcodeFormat Format
+		{
+			get => format;
+			init
+			{
+				if (!Enum.IsDefined(value))
+					throw new ArgumentOutOfRangeException(nameof(value), "Barcode generation requires a single supported barcode format.");
+
+				format = value;
+			}
+		}
+
+		public int Width
+		{
+			get => width;
+			init => width = value > 0
+				? value
+				: throw new ArgumentOutOfRangeException(nameof(value), "Width must be greater than zero.");
+		}
+
+		public int Height
+		{
+			get => height;
+			init => height = value > 0
+				? value
+				: throw new ArgumentOutOfRangeException(nameof(value), "Height must be greater than zero.");
+		}
+
+		public int Margin
+		{
+			get => margin;
+			init => margin = value >= 0
+				? value
+				: throw new ArgumentOutOfRangeException(nameof(value), "Margin must be greater than or equal to zero.");
+		}
+
+		public Color ForegroundColor
+		{
+			get => foregroundColor;
+			init => foregroundColor = value ?? throw new ArgumentNullException(nameof(value));
+		}
+
+		public Color BackgroundColor
+		{
+			get => backgroundColor;
+			init => backgroundColor = value ?? throw new ArgumentNullException(nameof(value));
+		}
+
+		public string CharacterSet { get; init; }
+	}
+}

--- a/ZXing.Net.MAUI/BarcodeImageFormat.cs
+++ b/ZXing.Net.MAUI/BarcodeImageFormat.cs
@@ -1,0 +1,8 @@
+namespace ZXing.Net.Maui
+{
+	public enum BarcodeImageFormat
+	{
+		Png,
+		Jpeg
+	}
+}

--- a/ZXing.Net.MAUI/BarcodeImageOptions.cs
+++ b/ZXing.Net.MAUI/BarcodeImageOptions.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace ZXing.Net.Maui
+{
+	public record BarcodeImageOptions
+	{
+		BarcodeImageFormat format = BarcodeImageFormat.Png;
+
+		public static BarcodeImageOptions Default { get; } = new();
+
+		public BarcodeImageFormat Format
+		{
+			get => format;
+			init
+			{
+				if (!Enum.IsDefined(value))
+					throw new ArgumentOutOfRangeException(nameof(value), "Image format is not supported.");
+
+				format = value;
+			}
+		}
+	}
+}

--- a/ZXing.Net.MAUI/Net/BarcodeGenerator.net.cs
+++ b/ZXing.Net.MAUI/Net/BarcodeGenerator.net.cs
@@ -1,0 +1,17 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ZXing.Net.Maui
+{
+	public static partial class BarcodeGenerator
+	{
+		private static partial Task WriteImageToStreamAsync(
+			NativePlatformImage image,
+			Stream stream,
+			BarcodeImageOptions options,
+			CancellationToken cancellationToken)
+			=> throw new PlatformNotSupportedException("Barcode image writing requires Android, iOS, MacCatalyst, or Windows.");
+	}
+}

--- a/ZXing.Net.MAUI/Platforms/Android/BarcodeGenerator.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/BarcodeGenerator.android.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Android.Graphics;
+
+namespace ZXing.Net.Maui
+{
+	public static partial class BarcodeGenerator
+	{
+		private static partial async Task WriteImageToStreamAsync(
+			NativePlatformImage image,
+			Stream stream,
+			BarcodeImageOptions options,
+			CancellationToken cancellationToken)
+		{
+			ArgumentNullException.ThrowIfNull(image);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			var compressFormat = options.Format switch
+			{
+				BarcodeImageFormat.Png => Bitmap.CompressFormat.Png,
+				BarcodeImageFormat.Jpeg => Bitmap.CompressFormat.Jpeg,
+				_ => throw new ArgumentOutOfRangeException(nameof(options), "Image format is not supported on this platform.")
+			};
+
+			var encoded = await Task.Run(() => image.Compress(compressFormat, 100, stream), cancellationToken)
+				.ConfigureAwait(false);
+
+			if (!encoded)
+				throw new InvalidOperationException("The barcode image could not be encoded.");
+		}
+	}
+}

--- a/ZXing.Net.MAUI/Platforms/Windows/BarcodeGenerator.windows.cs
+++ b/ZXing.Net.MAUI/Platforms/Windows/BarcodeGenerator.windows.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Graphics.Imaging;
+using Windows.Storage.Streams;
+
+namespace ZXing.Net.Maui
+{
+	public static partial class BarcodeGenerator
+	{
+		private static partial async Task WriteImageToStreamAsync(
+			NativePlatformImage image,
+			Stream stream,
+			BarcodeImageOptions options,
+			CancellationToken cancellationToken)
+		{
+			ArgumentNullException.ThrowIfNull(image);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			var encoderId = options.Format switch
+			{
+				BarcodeImageFormat.Png => BitmapEncoder.PngEncoderId,
+				BarcodeImageFormat.Jpeg => BitmapEncoder.JpegEncoderId,
+				_ => throw new ArgumentOutOfRangeException(nameof(options), "Image format is not supported on this platform.")
+			};
+
+			using var memoryStream = new InMemoryRandomAccessStream();
+			var encoder = await BitmapEncoder.CreateAsync(encoderId, memoryStream)
+				.AsTask(cancellationToken)
+				.ConfigureAwait(false);
+
+			encoder.SetPixelData(
+				BitmapPixelFormat.Bgra8,
+				BitmapAlphaMode.Premultiplied,
+				(uint)image.PixelWidth,
+				(uint)image.PixelHeight,
+				96,
+				96,
+				image.PixelBuffer.ToArray());
+
+			await encoder.FlushAsync().AsTask(cancellationToken).ConfigureAwait(false);
+
+			memoryStream.Seek(0);
+			using var readStream = memoryStream.AsStreamForRead();
+			await readStream.CopyToAsync(stream, 81920, cancellationToken).ConfigureAwait(false);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Replaces stale draft PR #270 with a fresh implementation from current `main` that adds a small programmatic barcode image generation/export API.

- Adds `BarcodeGenerator.Generate(...)`, `GenerateAsync(...)`, `WriteToFileAsync(...)`, and `WriteToStreamAsync(...)`.
- Adds init-only `BarcodeGeneratorOptions` for generation settings and `BarcodeImageOptions`/`BarcodeImageFormat` for output format selection.
- Supports PNG and JPEG image writing on Android, iOS, MacCatalyst, and Windows, with explicit `PlatformNotSupportedException` behavior for the plain `net10.0` target.
- Keeps `BarcodeGeneratorView` and live camera scanning behavior stable.
- Optimizes the Apple barcode renderer by filling the background once and drawing contiguous foreground runs instead of issuing a draw call for every matrix cell.
- Adds a dedicated sample generator page with configurable value, writer format, output format, dimensions, margin, character set, foreground/background colors, live preview in an `Image`, and file saving.
- Filters the sample generator to barcode formats supported by the ZXing writer and applies value restrictions for formats with constrained alphabets/lengths.
- Makes the generator sample theme-safe in light/dark mode, pauses scanner detection while the generator page is active, shows a busy state/timing during preview generation, and reuses unchanged preview bytes when saving.
- Polishes the scanner sample overlay with grouped camera controls, a right-aligned `QR` generator action, zoom slider margin, and a readable scan result card that can show the full value on tap.
- Documents file/stream export usage in the README.

## API decisions

- Kept the public surface minimal and cross-platform: PNG/JPEG only, no native image extension methods, no platform-only formats.
- Added `GenerateAsync(...)` beside `Generate(...)` to align with the still-image decode PR's sync/async naming shape. It preserves the caller's thread rather than forcing platform-native image creation onto the thread pool.
- Used `WriteToFileAsync`/`WriteToStreamAsync` plus options records as the generator-centric export equivalent for selecting an output format.
- Preserved explicit errors for invalid values: empty barcode content, non-writable streams, invalid dimensions/margin, combined barcode formats, unsupported platforms.
- iOS/MacCatalyst export generation uses image scale `1` so requested width/height map to encoded pixels; the generator view renderer keeps its existing screen-scale default.
- `BarcodeImageFormat` is output-only and remains independent from the still-image decode API, which sniffs encoded input streams.

## Validation

- `dotnet test ZXing.Net.MAUI.Tests/ZXing.Net.MAUI.Tests.csproj --verbosity minimal` — 37 passed.
- `dotnet build BigIslandBarcode/BigIslandBarcode.csproj -f net10.0-ios -r ios-arm64 --verbosity minimal` — passed with .NET SDK 10.0.102 / Xcode 26.2.
- Installed and launched the updated sample on the connected physical iPhone 17 Pro (`com.companyname.BigIslandBarcode`).
- `dotnet build BigIslandBarcode/BigIslandBarcode.csproj -f net10.0-ios -r iossimulator-arm64 --verbosity minimal` — passed with .NET SDK 10.0.102 / Xcode 26.2.
- Installed and launched the updated sample on iPhone 11 iOS 26.2 simulator (`com.companyname.BigIslandBarcode`).
- `dotnet build BigIslandBarcode/BigIslandBarcode.csproj -f net10.0-android -r android-arm64 --verbosity minimal` — passed.
- `dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-maccatalyst --verbosity minimal` — passed.
- Earlier platform library validation passed for `net10.0`, Android, iOS, MacCatalyst, and Windows targeting.

## Linked issues

Fixes #80.
Fixes #96.