### PR TITLE
Add still image stream barcode decoding

### DIFF
--- a/BigIslandBarcode/MainPage.xaml
+++ b/BigIslandBarcode/MainPage.xaml
@@ -88,7 +88,7 @@
 			Grid.Row="2"
 			BackgroundColor="#99000000"
 			Padding="24,12,24,24"
-			ColumnDefinitions="Auto,Auto,Auto,Auto,*,Auto"
+			ColumnDefinitions="Auto,Auto,Auto,*,Auto,Auto"
 			ColumnSpacing="12">
 
 			<Button
@@ -113,10 +113,10 @@
 				Clicked="TorchButton_Clicked" />
 
 			<Button
-				Grid.Column="3"
+				Grid.Column="4"
 				Text="IMG"
 				FontSize="14"
-				Style="{StaticResource ScannerButtonStyle}"
+				Style="{StaticResource PrimaryScannerButtonStyle}"
 				AutomationProperties.Name="Decode image"
 				Clicked="DecodeImageButton_Clicked" />
 

--- a/BigIslandBarcode/MainPage.xaml
+++ b/BigIslandBarcode/MainPage.xaml
@@ -88,7 +88,7 @@
 			Grid.Row="2"
 			BackgroundColor="#99000000"
 			Padding="24,12,24,24"
-			ColumnDefinitions="Auto,Auto,Auto,*,Auto"
+			ColumnDefinitions="Auto,Auto,Auto,Auto,*,Auto"
 			ColumnSpacing="12">
 
 			<Button
@@ -113,7 +113,15 @@
 				Clicked="TorchButton_Clicked" />
 
 			<Button
-				Grid.Column="4"
+				Grid.Column="3"
+				Text="IMG"
+				FontSize="14"
+				Style="{StaticResource ScannerButtonStyle}"
+				AutomationProperties.Name="Decode image"
+				Clicked="DecodeImageButton_Clicked" />
+
+			<Button
+				Grid.Column="5"
 				Text="QR"
 				FontSize="18"
 				Style="{StaticResource PrimaryScannerButtonStyle}"

--- a/BigIslandBarcode/MainPage.xaml
+++ b/BigIslandBarcode/MainPage.xaml
@@ -42,7 +42,14 @@
 			VerticalOptions="End"
 			HorizontalOptions="Fill"
 			BackgroundColor="#aa000000">
-			<Slider Minimum="0" Maximum="1" Margin="24,0,24,8" ValueChanged="ZoomFactorChanged" />
+			<Slider
+				Minimum="0"
+				Maximum="1"
+				Margin="24,0,24,8"
+				MinimumTrackColor="#8B6DFF"
+				MaximumTrackColor="#66FFFFFF"
+				ThumbColor="White"
+				ValueChanged="ZoomFactorChanged" />
 		</Grid>
 
 		<Border

--- a/BigIslandBarcode/MainPage.xaml.cs
+++ b/BigIslandBarcode/MainPage.xaml.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Storage;
+using Microsoft.Maui.Media;
 using ZXing.Net.Maui;
 
 namespace BigIslandBarcode
@@ -116,7 +116,11 @@ namespace BigIslandBarcode
 		{
 			try
 			{
-				var file = await FilePicker.PickAsync(PickOptions.Images);
+				var files = await MediaPicker.Default.PickPhotosAsync(new MediaPickerOptions
+				{
+					Title = "Select barcode image"
+				});
+				var file = files?.FirstOrDefault();
 				if (file is null)
 					return;
 

--- a/BigIslandBarcode/MainPage.xaml.cs
+++ b/BigIslandBarcode/MainPage.xaml.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Storage;
 using ZXing.Net.Maui;
 
 namespace BigIslandBarcode
@@ -64,12 +66,7 @@ namespace BigIslandBarcode
 			{
 				Dispatcher.Dispatch(() =>
 				{
-					generatorFormat = first.Format;
-					generatorValue = first.Value;
-					lastScannedValue = first.Value;
-					ResultFormatLabel.Text = first.Format.ToString();
-					ResultValueLabel.Text = first.Value;
-					ResultHintLabel.IsVisible = true;
+					ShowBarcodeResult(first);
 				});
 			}
 		}
@@ -115,9 +112,68 @@ namespace BigIslandBarcode
 			barcodeView.IsTorchOn = !barcodeView.IsTorchOn;
 		}
 
+		async void DecodeImageButton_Clicked(object sender, EventArgs e)
+		{
+			try
+			{
+				var file = await FilePicker.PickAsync(PickOptions.Images);
+				if (file is null)
+					return;
+
+				await using var stream = await file.OpenReadAsync();
+				var results = await BarcodeReader.DecodeAsync(
+					stream,
+					new BarcodeReaderOptions
+					{
+						Formats = BarcodeFormats.All,
+						AutoRotate = true,
+						Multiple = true,
+						TryHarder = true,
+						TryInverted = true
+					});
+
+				var first = results.FirstOrDefault();
+				if (first is null)
+				{
+					ShowNoBarcodeResult("Image");
+					return;
+				}
+
+				ShowBarcodeResult(first);
+				await DisplayAlertAsync(first.Format.ToString(), first.Value, "OK");
+			}
+			catch (Exception ex) when (ex is ArgumentException
+				or IOException
+				or UnauthorizedAccessException
+				or PlatformNotSupportedException
+				or InvalidOperationException
+				or NotSupportedException)
+			{
+				await DisplayAlertAsync("Image Decode Failed", ex.Message, "OK");
+			}
+		}
+
 		async void GeneratorButton_Clicked(object sender, EventArgs e)
 		{
 			await Navigation.PushAsync(new GeneratorPage(generatorValue, generatorFormat));
+		}
+
+		void ShowBarcodeResult(BarcodeResult barcode)
+		{
+			generatorFormat = barcode.Format;
+			generatorValue = barcode.Value;
+			lastScannedValue = barcode.Value;
+			ResultFormatLabel.Text = barcode.Format.ToString();
+			ResultValueLabel.Text = barcode.Value;
+			ResultHintLabel.IsVisible = true;
+		}
+
+		void ShowNoBarcodeResult(string source)
+		{
+			lastScannedValue = null;
+			ResultFormatLabel.Text = source;
+			ResultValueLabel.Text = "No barcode found";
+			ResultHintLabel.IsVisible = false;
 		}
 
 		async void ResultPanel_Tapped(object sender, TappedEventArgs e)

--- a/README.md
+++ b/README.md
@@ -115,6 +115,32 @@ cameraBarcodeReaderView.Options = new BarcodeReaderOptions
 };
 ```
 
+### Decode barcodes from image files or streams
+
+Still-image decoding is available on Android, iOS, MacCatalyst, and Windows without starting the camera. The same `BarcodeReaderOptions` used by the camera reader also apply to image streams.
+
+```csharp
+using ZXing.Net.Maui;
+using var stream = await fileResult.OpenReadAsync();
+
+var results = await BarcodeReader.DecodeAsync(
+  stream,
+  new BarcodeReaderOptions
+  {
+    Formats = BarcodeFormats.All,
+    AutoRotate = true,
+    TryHarder = true,
+    Multiple = true
+  });
+
+foreach (var result in results ?? [])
+  Console.WriteLine($"{result.Format}: {result.Value}");
+```
+
+You can also decode directly from a file path with `BarcodeReader.DecodeFromFileAsync(...)`.
+
+EXIF orientation is respected before decoding when the platform image APIs expose it. The neutral `net10.0` target does not include a platform image decoder, so stream decoding there throws `PlatformNotSupportedException`.
+
 Toggle Torch
 ```csharp
 cameraBarcodeReaderView.IsTorchOn = !cameraBarcodeReaderView.IsTorchOn;

--- a/ZXing.Net.MAUI.Tests/BarcodeReaderOptionsTests.cs
+++ b/ZXing.Net.MAUI.Tests/BarcodeReaderOptionsTests.cs
@@ -14,6 +14,7 @@ public class BarcodeReaderOptionsTests
 		Assert.Equal(1000, options.DelayBetweenContinuousScans);
 		Assert.Equal(300, options.InitialDelayBeforeAnalyzingFrames);
 		Assert.Null(options.CameraResolutionSelector);
+		Assert.Equal(options, BarcodeReaderOptions.Default);
 	}
 
 	[Fact]
@@ -54,5 +55,39 @@ public class BarcodeReaderOptionsTests
 		]);
 
 		Assert.Same(expected, selected);
+	}
+
+	[Fact]
+	public void CreateReaderUsesProvidedOptions()
+	{
+		var options = new BarcodeReaderOptions
+		{
+			Formats = BarcodeFormats.TwoDimensional,
+			TryHarder = true
+		};
+
+		var reader = BarcodeReader.CreateReader(options);
+
+		Assert.Same(options, reader.Options);
+	}
+
+	[Fact]
+	public async Task DecodeAsyncHonorsAlreadyCanceledToken()
+	{
+		using var cancellationTokenSource = new CancellationTokenSource();
+		await cancellationTokenSource.CancelAsync();
+
+		await Assert.ThrowsAsync<OperationCanceledException>(() =>
+			BarcodeReader.DecodeAsync(Stream.Null, cancellationToken: cancellationTokenSource.Token));
+	}
+
+	[Fact]
+	public async Task DecodeFromFileAsyncHonorsAlreadyCanceledTokenBeforeOpeningFile()
+	{
+		using var cancellationTokenSource = new CancellationTokenSource();
+		await cancellationTokenSource.CancelAsync();
+
+		await Assert.ThrowsAsync<OperationCanceledException>(() =>
+			BarcodeReader.DecodeFromFileAsync("missing-image.png", cancellationToken: cancellationTokenSource.Token));
 	}
 }

--- a/ZXing.Net.MAUI.Tests/LuminanceBufferTests.cs
+++ b/ZXing.Net.MAUI.Tests/LuminanceBufferTests.cs
@@ -1,0 +1,78 @@
+using ZXing.Net.Maui;
+using ZXing.Net.Maui.Readers;
+
+namespace ZXing.Net.MAUI.Tests;
+
+public class LuminanceBufferTests
+{
+	[Fact]
+	public void Rgba32ToLuminanceHonorsRowStrideAndAlpha()
+	{
+		var source = new byte[]
+		{
+			255, 0, 0, 255,
+			0, 0, 0, 0,
+			99, 99, 99, 99,
+			0, 255, 0, 128,
+			0, 0, 255, 255
+		};
+		var luminance = new byte[4];
+
+		LuminanceBuffer.Rgba32ToLuminance(source, width: 2, height: 2, rowStride: 12, luminance);
+
+		Assert.Equal(new byte[]
+		{
+			LuminanceBuffer.FromRgba(255, 0, 0, 255),
+			LuminanceBuffer.FromRgba(0, 0, 0, 0),
+			LuminanceBuffer.FromRgba(0, 255, 0, 128),
+			LuminanceBuffer.FromRgba(0, 0, 255, 255)
+		}, luminance);
+	}
+
+	[Fact]
+	public void Bgra32ToLuminanceUsesBgraChannelOrder()
+	{
+		var source = new byte[]
+		{
+			0, 0, 255, 255,
+			0, 255, 0, 255,
+			255, 0, 0, 255
+		};
+		var luminance = new byte[3];
+
+		LuminanceBuffer.Bgra32ToLuminance(source, width: 3, height: 1, rowStride: 12, luminance);
+
+		Assert.Equal(new byte[]
+		{
+			LuminanceBuffer.FromRgba(255, 0, 0, 255),
+			LuminanceBuffer.FromRgba(0, 255, 0, 255),
+			LuminanceBuffer.FromRgba(0, 0, 255, 255)
+		}, luminance);
+	}
+
+	[Theory]
+	[InlineData((int)ImageOrientation.Normal, 3, 2, new byte[] { 1, 2, 3, 4, 5, 6 })]
+	[InlineData((int)ImageOrientation.FlipHorizontal, 3, 2, new byte[] { 3, 2, 1, 6, 5, 4 })]
+	[InlineData((int)ImageOrientation.Rotate180, 3, 2, new byte[] { 6, 5, 4, 3, 2, 1 })]
+	[InlineData((int)ImageOrientation.FlipVertical, 3, 2, new byte[] { 4, 5, 6, 1, 2, 3 })]
+	[InlineData((int)ImageOrientation.Transpose, 2, 3, new byte[] { 1, 4, 2, 5, 3, 6 })]
+	[InlineData((int)ImageOrientation.Rotate90, 2, 3, new byte[] { 4, 1, 5, 2, 6, 3 })]
+	[InlineData((int)ImageOrientation.Transverse, 2, 3, new byte[] { 6, 3, 5, 2, 4, 1 })]
+	[InlineData((int)ImageOrientation.Rotate270, 2, 3, new byte[] { 3, 6, 2, 5, 1, 4 })]
+	public void ApplyOrientationTransformsLuminanceMatrix(int orientationValue, int expectedWidth, int expectedHeight, byte[] expected)
+	{
+		var image = LuminanceBuffer.ApplyOrientation([1, 2, 3, 4, 5, 6], width: 3, height: 2, (ImageOrientation)orientationValue);
+
+		Assert.Equal(expectedWidth, image.Width);
+		Assert.Equal(expectedHeight, image.Height);
+		Assert.Equal(expected, image.Luminance);
+	}
+
+	[Fact]
+	public void ImageLuminanceDataRejectsInvalidDimensions()
+	{
+		Assert.Throws<ArgumentOutOfRangeException>(() => new ImageLuminanceData([], 0, 1));
+		Assert.Throws<ArgumentOutOfRangeException>(() => new ImageLuminanceData([], 1, 0));
+		Assert.Throws<ArgumentException>(() => new ImageLuminanceData([1, 2, 3], 2, 2));
+	}
+}

--- a/ZXing.Net.MAUI.Tests/ZXingBarcodeReaderImageTests.cs
+++ b/ZXing.Net.MAUI.Tests/ZXingBarcodeReaderImageTests.cs
@@ -1,0 +1,34 @@
+using ZXing.Net.Maui;
+using ZXing.Net.Maui.Readers;
+
+namespace ZXing.Net.MAUI.Tests;
+
+public class ZXingBarcodeReaderImageTests
+{
+	[Fact]
+	public void DecodeReadsSharedLuminanceDataWithConfiguredOptions()
+	{
+		var writer = new ZXing.QrCode.QRCodeWriter();
+		var matrix = writer.encode("stream decode", ZXing.BarcodeFormat.QR_CODE, 96, 96);
+		var luminance = new byte[matrix.Width * matrix.Height];
+
+		for (var y = 0; y < matrix.Height; y++)
+		{
+			for (var x = 0; x < matrix.Width; x++)
+				luminance[y * matrix.Width + x] = matrix[x, y] ? byte.MinValue : byte.MaxValue;
+		}
+
+		var reader = new ZXingBarcodeReader
+		{
+			Options = new BarcodeReaderOptions
+			{
+				Formats = BarcodeFormats.TwoDimensional,
+				TryHarder = true
+			}
+		};
+
+		var result = Assert.Single(reader.Decode(new ImageLuminanceData(luminance, matrix.Width, matrix.Height)));
+		Assert.Equal("stream decode", result.Value);
+		Assert.Equal(global::ZXing.Net.Maui.BarcodeFormat.QrCode, result.Format);
+	}
+}

--- a/ZXing.Net.MAUI/Apple/StillImageDecoder.ios.maccatalyst.cs
+++ b/ZXing.Net.MAUI/Apple/StillImageDecoder.ios.maccatalyst.cs
@@ -1,0 +1,76 @@
+﻿#if IOS || MACCATALYST
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CoreGraphics;
+using Foundation;
+using UIKit;
+
+namespace ZXing.Net.Maui.Readers
+{
+	internal static partial class StillImageDecoder
+	{
+		public static partial async Task<ImageLuminanceData> DecodeAsync(Stream imageStream, CancellationToken cancellationToken)
+		{
+			var encodedImage = await ImageStreamBuffer.ReadAllBytesAsync(imageStream, cancellationToken).ConfigureAwait(false);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			using var data = NSData.FromArray(encodedImage);
+			using var image = UIImage.LoadFromData(data);
+
+			if (image == null)
+				throw new InvalidDataException("The image stream could not be decoded as a UIImage.");
+
+			var cgImage = image.CGImage;
+			if (cgImage == null)
+				throw new InvalidDataException("The image stream did not contain bitmap-backed image data.");
+
+			var luminance = CreateLuminance(cgImage);
+			var orientation = ToImageOrientation(image.Orientation);
+
+			return LuminanceBuffer.ApplyOrientation(luminance, (int)cgImage.Width, (int)cgImage.Height, orientation);
+		}
+
+		static byte[] CreateLuminance(CGImage image)
+		{
+			var width = checked((int)image.Width);
+			var height = checked((int)image.Height);
+			var rowStride = checked(width * 4);
+			var pixels = new byte[checked(rowStride * height)];
+			var luminance = new byte[checked(width * height)];
+
+			using var colorSpace = CGColorSpace.CreateDeviceRGB();
+			using var context = new CGBitmapContext(
+				pixels,
+				width,
+				height,
+				8,
+				rowStride,
+				colorSpace,
+				CGBitmapFlags.ByteOrder32Little | (CGBitmapFlags)CGImageAlphaInfo.PremultipliedFirst);
+
+			context.TranslateCTM(0, height);
+			context.ScaleCTM(1, -1);
+			context.DrawImage(new CGRect(0, 0, width, height), image);
+			LuminanceBuffer.Bgra32ToLuminance(pixels, width, height, rowStride, luminance);
+
+			return luminance;
+		}
+
+		static ImageOrientation ToImageOrientation(UIImageOrientation orientation)
+			=> orientation switch
+			{
+				UIImageOrientation.Up => ImageOrientation.Normal,
+				UIImageOrientation.Down => ImageOrientation.Rotate180,
+				UIImageOrientation.Left => ImageOrientation.Rotate270,
+				UIImageOrientation.Right => ImageOrientation.Rotate90,
+				UIImageOrientation.UpMirrored => ImageOrientation.FlipHorizontal,
+				UIImageOrientation.DownMirrored => ImageOrientation.FlipVertical,
+				UIImageOrientation.LeftMirrored => ImageOrientation.Transpose,
+				UIImageOrientation.RightMirrored => ImageOrientation.Transverse,
+				_ => ImageOrientation.Normal
+			};
+	}
+}
+#endif

--- a/ZXing.Net.MAUI/BarcodeReader.cs
+++ b/ZXing.Net.MAUI/BarcodeReader.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ZXing.Net.Maui.Readers;
+
+namespace ZXing.Net.Maui
+{
+	public static class BarcodeReader
+	{
+		public static BarcodeResult[] Decode(Stream imageStream, BarcodeReaderOptions options = null)
+		{
+			ArgumentNullException.ThrowIfNull(imageStream);
+
+			var reader = CreateReader(options);
+			return reader.Decode(imageStream);
+		}
+
+		public static Task<BarcodeResult[]> DecodeAsync(
+			Stream imageStream,
+			BarcodeReaderOptions options = null,
+			CancellationToken cancellationToken = default)
+		{
+			ArgumentNullException.ThrowIfNull(imageStream);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			var reader = CreateReader(options);
+			return reader.DecodeAsync(imageStream, cancellationToken);
+		}
+
+		public static async Task<BarcodeResult[]> DecodeFromFileAsync(
+			string filePath,
+			BarcodeReaderOptions options = null,
+			CancellationToken cancellationToken = default)
+		{
+			ArgumentException.ThrowIfNullOrEmpty(filePath);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			await using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, true);
+			return await DecodeAsync(stream, options, cancellationToken).ConfigureAwait(false);
+		}
+
+		internal static ZXingBarcodeReader CreateReader(BarcodeReaderOptions options)
+			=> new()
+			{
+				Options = options ?? BarcodeReaderOptions.Default
+			};
+	}
+}

--- a/ZXing.Net.MAUI/BarcodeScannerOptions.cs
+++ b/ZXing.Net.MAUI/BarcodeScannerOptions.cs
@@ -19,6 +19,8 @@ namespace ZXing.Net.Maui
 		int delayBetweenContinuousScans = 1000;
 		int initialDelayBeforeAnalyzingFrames = 300;
 
+		public static BarcodeReaderOptions Default { get; } = new();
+
 		public bool AutoRotate { get; init; }
 
 		public bool TryHarder { get; init; }

--- a/ZXing.Net.MAUI/IBarcodeReader.cs
+++ b/ZXing.Net.MAUI/IBarcodeReader.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ZXing.Net.Maui.Readers
@@ -11,5 +10,14 @@ namespace ZXing.Net.Maui.Readers
 		BarcodeReaderOptions Options { get; set; }
 
 		BarcodeResult[] Decode(PixelBufferHolder image);
+
+		BarcodeResult[] Decode(Stream imageStream)
+			=> throw new NotSupportedException($"{GetType().Name} does not support decoding barcode images from streams.");
+
+		Task<BarcodeResult[]> DecodeAsync(Stream imageStream, CancellationToken cancellationToken = default)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			return Task.FromResult(Decode(imageStream));
+		}
 	}
 }

--- a/ZXing.Net.MAUI/ImageLuminanceData.cs
+++ b/ZXing.Net.MAUI/ImageLuminanceData.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace ZXing.Net.Maui.Readers
+{
+	internal readonly record struct ImageLuminanceData
+	{
+		public ImageLuminanceData(byte[] luminance, int width, int height)
+		{
+			ArgumentNullException.ThrowIfNull(luminance);
+
+			if (width <= 0)
+				throw new ArgumentOutOfRangeException(nameof(width), "Width must be greater than zero.");
+
+			if (height <= 0)
+				throw new ArgumentOutOfRangeException(nameof(height), "Height must be greater than zero.");
+
+			var requiredLength = checked(width * height);
+			if (luminance.Length < requiredLength)
+				throw new ArgumentException("The luminance buffer is smaller than the image dimensions require.", nameof(luminance));
+
+			Luminance = luminance;
+			Width = width;
+			Height = height;
+		}
+
+		public byte[] Luminance { get; }
+
+		public int Width { get; }
+
+		public int Height { get; }
+
+		public ImageLuminanceSource CreateLuminanceSource()
+			=> new(Luminance, Width, Height);
+	}
+}

--- a/ZXing.Net.MAUI/ImageLuminanceSource.cs
+++ b/ZXing.Net.MAUI/ImageLuminanceSource.cs
@@ -1,0 +1,13 @@
+﻿namespace ZXing.Net.Maui.Readers
+{
+	internal sealed class ImageLuminanceSource : BaseLuminanceSource
+	{
+		public ImageLuminanceSource(byte[] luminances, int width, int height)
+			: base(luminances, width, height)
+		{
+		}
+
+		protected override LuminanceSource CreateLuminanceSource(byte[] newLuminances, int width, int height)
+			=> new ImageLuminanceSource(newLuminances, width, height);
+	}
+}

--- a/ZXing.Net.MAUI/ImageOrientation.cs
+++ b/ZXing.Net.MAUI/ImageOrientation.cs
@@ -1,0 +1,15 @@
+﻿namespace ZXing.Net.Maui.Readers
+{
+	internal enum ImageOrientation
+	{
+		Undefined = 0,
+		Normal = 1,
+		FlipHorizontal = 2,
+		Rotate180 = 3,
+		FlipVertical = 4,
+		Transpose = 5,
+		Rotate90 = 6,
+		Transverse = 7,
+		Rotate270 = 8
+	}
+}

--- a/ZXing.Net.MAUI/ImageStreamBuffer.cs
+++ b/ZXing.Net.MAUI/ImageStreamBuffer.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ZXing.Net.Maui.Readers
+{
+	internal static class ImageStreamBuffer
+	{
+		const int DefaultBufferSize = 81920;
+
+		public static async Task<byte[]> ReadAllBytesAsync(Stream stream, CancellationToken cancellationToken)
+		{
+			ArgumentNullException.ThrowIfNull(stream);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			var capacity = 0;
+			if (stream.CanSeek)
+			{
+				var remaining = stream.Length - stream.Position;
+				if (remaining > int.MaxValue)
+					throw new InvalidDataException("The image stream is too large to buffer.");
+
+				if (remaining > 0)
+					capacity = (int)remaining;
+			}
+
+			using var memoryStream = capacity > 0 ? new MemoryStream(capacity) : new MemoryStream();
+			await stream.CopyToAsync(memoryStream, DefaultBufferSize, cancellationToken).ConfigureAwait(false);
+			return memoryStream.ToArray();
+		}
+	}
+}

--- a/ZXing.Net.MAUI/LuminanceBuffer.cs
+++ b/ZXing.Net.MAUI/LuminanceBuffer.cs
@@ -1,0 +1,156 @@
+﻿using System;
+
+namespace ZXing.Net.Maui.Readers
+{
+	internal static class LuminanceBuffer
+	{
+		const int ChannelWeight = 10;
+		const int RChannelWeight = 306;
+		const int GChannelWeight = 601;
+		const int BChannelWeight = 117;
+		const int BytesPerPixel = 4;
+
+		public static byte FromRgb(byte red, byte green, byte blue)
+			=> (byte)((RChannelWeight * red + GChannelWeight * green + BChannelWeight * blue + (1 << (ChannelWeight - 1))) >> ChannelWeight);
+
+		public static byte FromRgba(byte red, byte green, byte blue, byte alpha)
+			=> CompositeOnWhite(FromRgb(red, green, blue), alpha);
+
+		public static byte FromArgb(int argb)
+			=> FromRgba(
+				(byte)((argb >> 16) & 0xff),
+				(byte)((argb >> 8) & 0xff),
+				(byte)(argb & 0xff),
+				(byte)((argb >> 24) & 0xff));
+
+		public static void Rgba32ToLuminance(ReadOnlySpan<byte> source, int width, int height, int rowStride, Span<byte> destination)
+			=> FourChannelToLuminance(source, width, height, rowStride, destination, redOffset: 0, greenOffset: 1, blueOffset: 2, alphaOffset: 3);
+
+		public static void Bgra32ToLuminance(ReadOnlySpan<byte> source, int width, int height, int rowStride, Span<byte> destination)
+			=> FourChannelToLuminance(source, width, height, rowStride, destination, redOffset: 2, greenOffset: 1, blueOffset: 0, alphaOffset: 3);
+
+		public static ImageLuminanceData ApplyOrientation(byte[] luminance, int width, int height, ImageOrientation orientation)
+		{
+			_ = new ImageLuminanceData(luminance, width, height);
+
+			if (orientation is ImageOrientation.Undefined or ImageOrientation.Normal)
+				return new ImageLuminanceData(luminance, width, height);
+
+			var transpose = orientation is ImageOrientation.Transpose or ImageOrientation.Rotate90 or ImageOrientation.Transverse or ImageOrientation.Rotate270;
+			var destinationWidth = transpose ? height : width;
+			var destinationHeight = transpose ? width : height;
+			var destination = new byte[checked(destinationWidth * destinationHeight)];
+
+			for (var y = 0; y < height; y++)
+			{
+				for (var x = 0; x < width; x++)
+				{
+					var destinationIndex = GetOrientedIndex(x, y, width, height, destinationWidth, orientation);
+					destination[destinationIndex] = luminance[y * width + x];
+				}
+			}
+
+			return new ImageLuminanceData(destination, destinationWidth, destinationHeight);
+		}
+
+		static void FourChannelToLuminance(
+			ReadOnlySpan<byte> source,
+			int width,
+			int height,
+			int rowStride,
+			Span<byte> destination,
+			int redOffset,
+			int greenOffset,
+			int blueOffset,
+			int alphaOffset)
+		{
+			ValidateDimensions(width, height);
+
+			var minimumRowStride = checked(width * BytesPerPixel);
+			if (rowStride < minimumRowStride)
+				throw new ArgumentOutOfRangeException(nameof(rowStride), "Row stride must include every pixel in a row.");
+
+			var requiredSourceLength = checked(rowStride * (height - 1) + minimumRowStride);
+			if (source.Length < requiredSourceLength)
+				throw new ArgumentException("The source buffer is smaller than the image dimensions and row stride require.", nameof(source));
+
+			var requiredDestinationLength = checked(width * height);
+			if (destination.Length < requiredDestinationLength)
+				throw new ArgumentException("The destination buffer is smaller than the image dimensions require.", nameof(destination));
+
+			for (var y = 0; y < height; y++)
+			{
+				var sourceRow = source.Slice(y * rowStride, minimumRowStride);
+				var destinationRow = destination.Slice(y * width, width);
+
+				for (var x = 0; x < width; x++)
+				{
+					var sourceOffset = x * BytesPerPixel;
+					destinationRow[x] = FromRgba(
+						sourceRow[sourceOffset + redOffset],
+						sourceRow[sourceOffset + greenOffset],
+						sourceRow[sourceOffset + blueOffset],
+						sourceRow[sourceOffset + alphaOffset]);
+				}
+			}
+		}
+
+		static int GetOrientedIndex(int x, int y, int width, int height, int destinationWidth, ImageOrientation orientation)
+		{
+			var destinationX = x;
+			var destinationY = y;
+
+			switch (orientation)
+			{
+				case ImageOrientation.FlipHorizontal:
+					destinationX = width - 1 - x;
+					break;
+				case ImageOrientation.Rotate180:
+					destinationX = width - 1 - x;
+					destinationY = height - 1 - y;
+					break;
+				case ImageOrientation.FlipVertical:
+					destinationY = height - 1 - y;
+					break;
+				case ImageOrientation.Transpose:
+					destinationX = y;
+					destinationY = x;
+					break;
+				case ImageOrientation.Rotate90:
+					destinationX = height - 1 - y;
+					destinationY = x;
+					break;
+				case ImageOrientation.Transverse:
+					destinationX = height - 1 - y;
+					destinationY = width - 1 - x;
+					break;
+				case ImageOrientation.Rotate270:
+					destinationX = y;
+					destinationY = width - 1 - x;
+					break;
+			}
+
+			return destinationY * destinationWidth + destinationX;
+		}
+
+		static byte CompositeOnWhite(byte luminance, byte alpha)
+		{
+			if (alpha == byte.MaxValue)
+				return luminance;
+
+			if (alpha == byte.MinValue)
+				return byte.MaxValue;
+
+			return (byte)((luminance * alpha + byte.MaxValue * (byte.MaxValue - alpha) + 127) / byte.MaxValue);
+		}
+
+		static void ValidateDimensions(int width, int height)
+		{
+			if (width <= 0)
+				throw new ArgumentOutOfRangeException(nameof(width), "Width must be greater than zero.");
+
+			if (height <= 0)
+				throw new ArgumentOutOfRangeException(nameof(height), "Height must be greater than zero.");
+		}
+	}
+}

--- a/ZXing.Net.MAUI/Net/StillImageDecoder.net.cs
+++ b/ZXing.Net.MAUI/Net/StillImageDecoder.net.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ZXing.Net.Maui.Readers
+{
+	internal static partial class StillImageDecoder
+	{
+		public static partial Task<ImageLuminanceData> DecodeAsync(Stream imageStream, CancellationToken cancellationToken)
+			=> throw new PlatformNotSupportedException("Decoding barcode images from streams requires Android, iOS, MacCatalyst, or Windows.");
+	}
+}

--- a/ZXing.Net.MAUI/Platforms/Android/StillImageDecoder.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/StillImageDecoder.android.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Android.Graphics;
+using AndroidX.ExifInterface.Media;
+
+namespace ZXing.Net.Maui.Readers
+{
+	internal static partial class StillImageDecoder
+	{
+		public static partial async Task<ImageLuminanceData> DecodeAsync(Stream imageStream, CancellationToken cancellationToken)
+		{
+			var encodedImage = await ImageStreamBuffer.ReadAllBytesAsync(imageStream, cancellationToken).ConfigureAwait(false);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			using var bitmap = DecodeBitmap(encodedImage);
+			var luminance = BitmapToLuminance(bitmap);
+			var orientation = ReadOrientation(encodedImage);
+
+			return LuminanceBuffer.ApplyOrientation(luminance, bitmap.Width, bitmap.Height, orientation);
+		}
+
+		static Bitmap DecodeBitmap(byte[] encodedImage)
+		{
+			var options = new BitmapFactory.Options
+			{
+				InPreferredConfig = Bitmap.Config.Argb8888
+			};
+
+			var bitmap = BitmapFactory.DecodeByteArray(encodedImage, 0, encodedImage.Length, options);
+			if (bitmap == null)
+				throw new InvalidDataException("The image stream could not be decoded as a bitmap.");
+
+			return bitmap;
+		}
+
+		static byte[] BitmapToLuminance(Bitmap bitmap)
+		{
+			var width = bitmap.Width;
+			var height = bitmap.Height;
+			var luminance = new byte[checked(width * height)];
+			var row = new int[width];
+
+			for (var y = 0; y < height; y++)
+			{
+				bitmap.GetPixels(row, 0, width, 0, y, width, 1);
+
+				var destinationOffset = y * width;
+				for (var x = 0; x < width; x++)
+					luminance[destinationOffset + x] = LuminanceBuffer.FromArgb(row[x]);
+			}
+
+			return luminance;
+		}
+
+		static ImageOrientation ReadOrientation(byte[] encodedImage)
+		{
+			try
+			{
+				using var inputStream = new MemoryStream(encodedImage);
+				using var exif = new ExifInterface(inputStream);
+
+				return (ImageOrientation)exif.GetAttributeInt(ExifInterface.TagOrientation, (int)ImageOrientation.Normal);
+			}
+			catch (Java.IO.IOException)
+			{
+				return ImageOrientation.Normal;
+			}
+		}
+	}
+}

--- a/ZXing.Net.MAUI/Platforms/Windows/StillImageDecoder.windows.cs
+++ b/ZXing.Net.MAUI/Platforms/Windows/StillImageDecoder.windows.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Graphics.Imaging;
+
+namespace ZXing.Net.Maui.Readers
+{
+	internal static partial class StillImageDecoder
+	{
+		public static partial async Task<ImageLuminanceData> DecodeAsync(Stream imageStream, CancellationToken cancellationToken)
+		{
+			var encodedImage = await ImageStreamBuffer.ReadAllBytesAsync(imageStream, cancellationToken).ConfigureAwait(false);
+			cancellationToken.ThrowIfCancellationRequested();
+
+			using var memoryStream = new MemoryStream(encodedImage);
+			using var randomAccessStream = memoryStream.AsRandomAccessStream();
+			var decoder = await BitmapDecoder.CreateAsync(randomAccessStream).AsTask(cancellationToken).ConfigureAwait(false);
+			using var bitmap = await decoder.GetSoftwareBitmapAsync(
+					BitmapPixelFormat.Gray8,
+					BitmapAlphaMode.Ignore,
+					new BitmapTransform(),
+					ExifOrientationMode.RespectExifOrientation,
+					ColorManagementMode.DoNotColorManage)
+				.AsTask(cancellationToken)
+				.ConfigureAwait(false);
+
+			var luminance = new byte[checked(bitmap.PixelWidth * bitmap.PixelHeight)];
+			bitmap.CopyToBuffer(luminance.AsBuffer());
+
+			return new ImageLuminanceData(luminance, bitmap.PixelWidth, bitmap.PixelHeight);
+		}
+	}
+}

--- a/ZXing.Net.MAUI/StillImageDecoder.cs
+++ b/ZXing.Net.MAUI/StillImageDecoder.cs
@@ -1,0 +1,14 @@
+﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ZXing.Net.Maui.Readers
+{
+	internal static partial class StillImageDecoder
+	{
+		public static ImageLuminanceData Decode(Stream imageStream)
+			=> DecodeAsync(imageStream, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		public static partial Task<ImageLuminanceData> DecodeAsync(Stream imageStream, CancellationToken cancellationToken = default);
+	}
+}

--- a/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
+++ b/ZXing.Net.MAUI/ZXing.Net.MAUI.csproj
@@ -24,6 +24,7 @@
 		<PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.4.2.3" />
 		<PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.4.2.3" />
 		<PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.4.2.3" />
+		<PackageReference Include="Xamarin.AndroidX.ExifInterface" Version="1.4.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="ZXing.Net" Version="0.16.11" />

--- a/ZXing.Net.MAUI/ZXingBarcodeReader.cs
+++ b/ZXing.Net.MAUI/ZXingBarcodeReader.cs
@@ -1,4 +1,9 @@
-﻿namespace ZXing.Net.Maui.Readers
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ZXing.Net.Maui.Readers
 {
 	public class ZXingBarcodeReader : Readers.IBarcodeReader
 	{
@@ -7,23 +12,18 @@
 		public ZXingBarcodeReader()
 		{
 			zxingReader = new BarcodeReaderGeneric();
+			Options = BarcodeReaderOptions.Default;
 		}
 
 		BarcodeReaderOptions options;
 		public BarcodeReaderOptions Options
 		{
 
-			get => options ??= new BarcodeReaderOptions();
+			get => options ??= BarcodeReaderOptions.Default;
 			set
 			{
-				options = value ?? new BarcodeReaderOptions();
-				zxingReader.Options.PossibleFormats = options.Formats.ToZXingList();
-				zxingReader.Options.TryHarder = options.TryHarder;
-				zxingReader.AutoRotate = options.AutoRotate;
-				zxingReader.Options.TryInverted = options.TryInverted;
-				zxingReader.Options.UseCode39ExtendedMode = options.UseCode39ExtendedMode;
-				zxingReader.Options.CharacterSet = options.CharacterSet;
-				zxingReader.Options.AssumeGS1 = options.AssumeGS1;
+				options = value ?? BarcodeReaderOptions.Default;
+				ApplyOptions(options);
 			}
 		}
 
@@ -43,6 +43,30 @@
 			ls = new SoftwareBitmapLuminanceSource(image.Data);
 #endif
 
+			return Decode(ls);
+		}
+
+		public BarcodeResult[] Decode(Stream imageStream)
+		{
+			ArgumentNullException.ThrowIfNull(imageStream);
+
+			var image = StillImageDecoder.Decode(imageStream);
+			return Decode(image);
+		}
+
+		public async Task<BarcodeResult[]> DecodeAsync(Stream imageStream, CancellationToken cancellationToken = default)
+		{
+			ArgumentNullException.ThrowIfNull(imageStream);
+
+			var image = await StillImageDecoder.DecodeAsync(imageStream, cancellationToken).ConfigureAwait(false);
+			return Decode(image);
+		}
+
+		internal BarcodeResult[] Decode(ImageLuminanceData image)
+			=> Decode(image.CreateLuminanceSource());
+
+		BarcodeResult[] Decode(LuminanceSource ls)
+		{
 			if (Options.Multiple)
 				return zxingReader.DecodeMultiple(ls)?.ToBarcodeResults();
 
@@ -51,6 +75,17 @@
 				return [b];
 
 			return null;
+		}
+
+		void ApplyOptions(BarcodeReaderOptions options)
+		{
+			zxingReader.Options.PossibleFormats = options.Formats.ToZXingList();
+			zxingReader.Options.TryHarder = options.TryHarder;
+			zxingReader.AutoRotate = options.AutoRotate;
+			zxingReader.Options.TryInverted = options.TryInverted;
+			zxingReader.Options.UseCode39ExtendedMode = options.UseCode39ExtendedMode;
+			zxingReader.Options.CharacterSet = options.CharacterSet;
+			zxingReader.Options.AssumeGS1 = options.AssumeGS1;
 		}
 
 #if ANDROID


### PR DESCRIPTION
## Summary
- Rebased onto current `main` after PR #312 merged.
- Add still-image stream decoding to `IBarcodeReader`/`ZXingBarcodeReader` while preserving the existing `PixelBufferHolder` live camera decode path.
- Add a root `BarcodeReader` programmatic facade aligned with the merged `BarcodeGenerator` API:
  - `BarcodeReader.Decode(Stream imageStream, BarcodeReaderOptions? options = null)`
  - `BarcodeReader.DecodeAsync(Stream imageStream, BarcodeReaderOptions? options = null, CancellationToken cancellationToken = default)`
  - `BarcodeReader.DecodeFromFileAsync(string filePath, BarcodeReaderOptions? options = null, CancellationToken cancellationToken = default)`
- Add native stream image decoders for Android, iOS/MacCatalyst, and Windows that convert encoded image streams to shared luminance data and account for EXIF orientation where available.
- Add shared luminance conversion/orientation helpers with unit coverage and document file/stream usage in the README.
- Add a minimal sample `IMG` flow that sits beside the `QR` button, uses the matching purple action style, and decodes the first selected `MediaPicker` image stream with `BarcodeReader.DecodeAsync(...)`.

## API alignment with generation/export work
- Generation remains generator-centric: `BarcodeGenerator.Generate/GenerateAsync`, `WriteToStreamAsync`, and `WriteToFileAsync`.
- Decode now has a matching root facade for programmatic use while keeping `IBarcodeReader`/`ZXingBarcodeReader` for DI, camera, and advanced reader reuse.
- `BarcodeReaderOptions.Default` mirrors the options-default pattern from `BarcodeGeneratorOptions.Default`.
- Decode stays stream-sniffing and does not use `BarcodeImageFormat`, which remains output-only for generation/export.

## Validation
- `dotnet test ZXing.Net.MAUI.Tests/ZXing.Net.MAUI.Tests.csproj --no-restore --verbosity minimal` (52 passed)
- `dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-android --no-restore --verbosity minimal`
- `dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-ios --no-restore --verbosity minimal`
- `dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-maccatalyst --no-restore --verbosity minimal`
- `dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-windows10.0.19041 -p:EnableWindowsTargeting=true -p:TargetFrameworks=net10.0-windows10.0.19041 --verbosity minimal`
- `dotnet build BigIslandBarcode/BigIslandBarcode.csproj -f net10.0-android --verbosity minimal`
- Android emulator manual verification: launched `BigIslandBarcode`, tapped `IMG`, selected a QR PNG from the image picker, and decoded `QrCode` with value `ZXing.Net.Maui image decode verification`.
- Physical iOS device verification: built the sample for `net10.0-ios/ios-arm64` with the installed .NET 10.0.102/Xcode 26.2-compatible workload, installed `BigIslandBarcode.app` to the paired iPhone (`00008150-000669001452401C`) with `xcrun devicectl device install app`, and launched `com.companyname.BigIslandBarcode` with `xcrun devicectl device process launch` after the MediaPicker UI update.

## Notes
- The neutral `net10.0` target compiles and keeps camera-independent tests, but stream image decoding there throws `PlatformNotSupportedException` because no platform image decoder is available.
- The default SDK on this machine currently resolves an iOS/MacCatalyst workload that requires Xcode 26.4, while Xcode 26.2 is installed. Physical iOS verification used the installed .NET 10.0.102 workload, which matches Xcode 26.2.