### PR TITLE
Fix Android camera preview containment

### DIFF
--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -54,6 +54,11 @@ namespace ZXing.Net.Maui
         public NativePlatformCameraPreviewView CreateNativeView()
         {
             _previewView = new PreviewView(Context.Context);
+            _previewView.SetImplementationMode(PreviewView.ImplementationMode.Compatible);
+            _previewView.SetClipChildren(true);
+            _previewView.SetClipToPadding(true);
+            _previewView.OutlineProvider = Android.Views.ViewOutlineProvider.Bounds;
+            _previewView.ClipToOutline = true;
             _cameraExecutor = Executors.NewSingleThreadExecutor();
 
             return _previewView;


### PR DESCRIPTION
## Summary
- Configure Android CameraX `PreviewView` to use compatible rendering so the preview surface behaves like a normal clipped view in constrained MAUI layouts.
- Enable child, padding, and outline clipping on the `PreviewView` so grids, popups, and borders can contain the camera preview bounds.
- Keep the existing default `PreviewView` scale behavior; this does not switch to `FitCenter` or introduce letterboxing.

## Validation
- `dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-android`
- `dotnet test ZXing.Net.MAUI.Tests/ZXing.Net.MAUI.Tests.csproj`

## Risk
- This relies on CameraX compatible mode (`TextureView`) instead of the default performance path, which favors layout correctness/clipping over possible `SurfaceView` performance optimizations.

Fixes #4
Fixes #71
Fixes #250
Fixes #285