### PR TITLE
Fix Android default zoom ratio

### DIFF
--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -4,6 +4,8 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
+using Android.Hardware.Camera2;
+using AndroidX.Camera.Camera2.InterOp;
 using AndroidX.Camera.Core;
 using AndroidX.Camera.Core.ResolutionSelector;
 using AndroidX.Camera.Lifecycle;
@@ -50,6 +52,7 @@ namespace ZXing.Net.Maui
         private bool _isDisposed;
 
         private static readonly Android.Util.Size DefaultResolution = new(640, 480);
+        private static readonly Java.Lang.Integer ContinuousPictureAutoFocusMode = Java.Lang.Integer.ValueOf((int)ControlAFMode.ContinuousPicture);
 
         public NativePlatformCameraPreviewView CreateNativeView()
         {
@@ -270,25 +273,37 @@ namespace ZXing.Net.Maui
             _resolutionSelector?.Dispose();
             _resolutionSelector = CreateResolutionSelector();
 
-            _cameraPreview?.Dispose();
-            _cameraPreview = new Preview
+            var previewBuilder = new Preview
                 .Builder()
-                .SetResolutionSelector(_resolutionSelector)
-                .Build();
+                .SetResolutionSelector(_resolutionSelector);
+
+            ApplyContinuousAutoFocus(previewBuilder);
+
+            _cameraPreview?.Dispose();
+            _cameraPreview = previewBuilder.Build();
 
             _cameraPreview.SetSurfaceProvider(cameraExecutor, previewView.SurfaceProvider);
 
-            _imageAnalyzer?.Dispose();
-            _imageAnalyzer = new ImageAnalysis
+            var imageAnalysisBuilder = new ImageAnalysis
                 .Builder()
                 .SetOutputImageFormat(ImageAnalysis.OutputImageFormatRgba8888)
                 .SetOutputImageRotationEnabled(Options.AutoRotate)
                 .SetResolutionSelector(_resolutionSelector)
-                .SetBackpressureStrategy(ImageAnalysis.StrategyKeepOnlyLatest)
-                .Build();
+                .SetBackpressureStrategy(ImageAnalysis.StrategyKeepOnlyLatest);
+
+            ApplyContinuousAutoFocus(imageAnalysisBuilder);
+
+            _imageAnalyzer?.Dispose();
+            _imageAnalyzer = imageAnalysisBuilder.Build();
 
             _imageAnalyzer.SetAnalyzer(cameraExecutor, new FrameAnalyzer((buffer, size) =>
                 FrameReady?.Invoke(this, new CameraFrameBufferEventArgs(new Readers.PixelBufferHolder { Data = buffer, Size = size }))));
+        }
+
+        static void ApplyContinuousAutoFocus(IExtendableBuilder builder)
+        {
+            new Camera2Interop.Extender(builder)
+                .SetCaptureRequestOption(CaptureRequest.ControlAfMode, ContinuousPictureAutoFocusMode);
         }
 
         ResolutionSelector CreateResolutionSelector()

--- a/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
+++ b/ZXing.Net.MAUI/Platforms/Android/CameraManager.android.cs
@@ -4,8 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
-using Android.Hardware.Camera2;
-using AndroidX.Camera.Camera2.InterOp;
 using AndroidX.Camera.Core;
 using AndroidX.Camera.Core.ResolutionSelector;
 using AndroidX.Camera.Lifecycle;
@@ -52,7 +50,6 @@ namespace ZXing.Net.Maui
         private bool _isDisposed;
 
         private static readonly Android.Util.Size DefaultResolution = new(640, 480);
-        private static readonly Java.Lang.Integer ContinuousPictureAutoFocusMode = Java.Lang.Integer.ValueOf((int)ControlAFMode.ContinuousPicture);
 
         public NativePlatformCameraPreviewView CreateNativeView()
         {
@@ -273,37 +270,25 @@ namespace ZXing.Net.Maui
             _resolutionSelector?.Dispose();
             _resolutionSelector = CreateResolutionSelector();
 
-            var previewBuilder = new Preview
-                .Builder()
-                .SetResolutionSelector(_resolutionSelector);
-
-            ApplyContinuousAutoFocus(previewBuilder);
-
             _cameraPreview?.Dispose();
-            _cameraPreview = previewBuilder.Build();
+            _cameraPreview = new Preview
+                .Builder()
+                .SetResolutionSelector(_resolutionSelector)
+                .Build();
 
             _cameraPreview.SetSurfaceProvider(cameraExecutor, previewView.SurfaceProvider);
 
-            var imageAnalysisBuilder = new ImageAnalysis
+            _imageAnalyzer?.Dispose();
+            _imageAnalyzer = new ImageAnalysis
                 .Builder()
                 .SetOutputImageFormat(ImageAnalysis.OutputImageFormatRgba8888)
                 .SetOutputImageRotationEnabled(Options.AutoRotate)
                 .SetResolutionSelector(_resolutionSelector)
-                .SetBackpressureStrategy(ImageAnalysis.StrategyKeepOnlyLatest);
-
-            ApplyContinuousAutoFocus(imageAnalysisBuilder);
-
-            _imageAnalyzer?.Dispose();
-            _imageAnalyzer = imageAnalysisBuilder.Build();
+                .SetBackpressureStrategy(ImageAnalysis.StrategyKeepOnlyLatest)
+                .Build();
 
             _imageAnalyzer.SetAnalyzer(cameraExecutor, new FrameAnalyzer((buffer, size) =>
                 FrameReady?.Invoke(this, new CameraFrameBufferEventArgs(new Readers.PixelBufferHolder { Data = buffer, Size = size }))));
-        }
-
-        static void ApplyContinuousAutoFocus(IExtendableBuilder builder)
-        {
-            new Camera2Interop.Extender(builder)
-                .SetCaptureRequestOption(CaptureRequest.ControlAfMode, ContinuousPictureAutoFocusMode);
         }
 
         ResolutionSelector CreateResolutionSelector()
@@ -365,7 +350,26 @@ namespace ZXing.Net.Maui
 
         partial void ApplyZoomFactor()
         {
-            _camera?.CameraControl?.SetLinearZoom(ZoomFactor);
+            var camera = _camera;
+            if (camera == null)
+                return;
+
+            var zoomState = camera.CameraInfo?.ZoomState?.Value as IZoomState;
+            if (zoomState == null)
+            {
+                if (ZoomFactor <= 0f)
+                    camera.CameraControl?.SetZoomRatio(1f);
+                else
+                    camera.CameraControl?.SetLinearZoom(ZoomFactor);
+
+                return;
+            }
+
+            var minZoomRatio = Math.Max(1f, zoomState.MinZoomRatio);
+            var maxZoomRatio = Math.Max(minZoomRatio, zoomState.MaxZoomRatio);
+            var zoomRatio = ZoomFactor * (maxZoomRatio - minZoomRatio) + minZoomRatio;
+
+            camera.CameraControl?.SetZoomRatio(zoomRatio);
         }
 
         public void Focus(Point point)


### PR DESCRIPTION
## Summary

- Fix Android `ZoomFactor` mapping so the default value (`0`) resolves to 1x zoom, matching Apple/Windows behavior
- Avoid using CameraX `SetLinearZoom(0)` as the default because on logical multi-camera devices such as Pixel 7 the minimum zoom ratio can select an ultrawide/fixed-focus physical camera
- Keep higher `ZoomFactor` values mapped from 1x to the camera's max zoom ratio

Fixes #315.

Thanks @sbrunaugh for testing the first artifact. That ruled out the explicit continuous-AF approach and pointed back to the 0.8.2 → 0.9.0 regression. The key change in that range was the new Android zoom path: default `ZoomFactor = 0` started calling `SetLinearZoom(0)`, unlike 0.8.2 which never applied zoom and unlike Apple/Windows which treat `0` as 1x. On Pixel 7, CameraX minimum zoom can switch to the ultrawide/fixed-focus lens, which matches the blurry/no-continuous-focus behavior.

Once the updated PR build artifacts are available, please try the new artifacts and let us know whether the preview/scanning focus behavior is back to the 0.8.2 behavior on your Pixel 7.

## Validation

- `dotnet test ZXing.Net.MAUI.Tests/ZXing.Net.MAUI.Tests.csproj --no-restore --verbosity minimal`
- `dotnet build ZXing.Net.MAUI/ZXing.Net.MAUI.csproj -f net10.0-android --no-restore --verbosity minimal`